### PR TITLE
Command Authorization Middleware and Suggest Command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "pingou",
       "dependencies": {
-        "@types/pg": "^8.20.0",
         "drizzle-orm": "^0.45.2",
         "pg": "^8.20.0",
         "seyfert": "^4.3.0",
@@ -15,6 +14,7 @@
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
         "@types/bun": "latest",
+        "@types/pg": "^8.20.0",
         "drizzle-kit": "^0.31.10",
         "lint-staged": "^16.4.0",
       },

--- a/commands.json
+++ b/commands.json
@@ -1,0 +1,31 @@
+[
+	{
+		"name": "suggest",
+		"type": 1,
+		"nsfw": false,
+		"description": "Haz una sugerencia al servidor",
+		"contexts": [0, 1, 2],
+		"integration_types": [0],
+		"options": [
+			{
+				"name": "sugerencia",
+				"description": "Escribe aqui el contenido de tu sugerencia",
+				"required": true,
+				"min_length": 40,
+				"type": 3,
+				"name_localizations": {},
+				"description_localizations": {},
+				"autocomplete": false
+			}
+		]
+	},
+	{
+		"name": "ping",
+		"type": 1,
+		"nsfw": false,
+		"description": "Mira la latencia del bot",
+		"contexts": [0, 1, 2],
+		"integration_types": [0],
+		"options": []
+	}
+]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"@commitlint/cli": "^20.5.0",
 		"@commitlint/config-conventional": "^20.5.0",
 		"@types/bun": "latest",
+		"@types/pg": "^8.20.0",
 		"drizzle-kit": "^0.31.10",
 		"lint-staged": "^16.4.0"
 	},
@@ -29,7 +30,6 @@
 		"prepare": "husky install"
 	},
 	"dependencies": {
-		"@types/pg": "^8.20.0",
 		"drizzle-orm": "^0.45.2",
 		"pg": "^8.20.0",
 		"seyfert": "^4.3.0"

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,8 +1,12 @@
 import { Command, type CommandContext, Declare, Embed } from "seyfert";
+import { CONFIG } from "../config/config";
 
 @Declare({
 	name: "ping",
 	description: "Mira la latencia del bot",
+	props: {
+		requiredRoles: [CONFIG.ROLES.ADMIN]
+	}
 })
 export default class PingCommand extends Command {
 	override async run(ctx: CommandContext) {

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -5,8 +5,8 @@ import { CONFIG } from "../config/config";
 	name: "ping",
 	description: "Mira la latencia del bot",
 	props: {
-		requiredRoles: [CONFIG.ROLES.ADMIN]
-	}
+		requiredRoles: [CONFIG.ROLES.ADMIN],
+	},
 })
 export default class PingCommand extends Command {
 	override async run(ctx: CommandContext) {

--- a/src/commands/suggestions/suggest.ts
+++ b/src/commands/suggestions/suggest.ts
@@ -1,0 +1,47 @@
+import {
+	Command,
+	type CommandContext,
+	createStringOption,
+	Declare,
+	Options,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { Embeds } from "../../utils/embeds";
+
+const options = {
+	sugerencia: createStringOption({
+		description: "Escribe aqui el contenido de tu sugerencia",
+		required: true,
+		min_length: 40,
+	}),
+};
+
+@Declare({
+	name: "suggest",
+	description: "Haz una sugerencia al servidor",
+})
+@Options(options)
+export default class SuggestCommand extends Command {
+	override async run(ctx: CommandContext<typeof options>) {
+		const { sugerencia } = ctx.options;
+
+		const suggestion = await ctx.client.messages.write(ctx.channelId, {
+			embeds: [Embeds.suggestionEmbed(ctx, sugerencia)],
+		});
+
+		await suggestion.react("✅");
+		await suggestion.react("❌");
+
+		await ctx.client.messages.thread(suggestion.channelId, suggestion.id, {
+			name: `Sugerencia de ${ctx.author.username}`,
+		});
+
+		return ctx.write({
+			content:
+				"Tu sugerencia se ha enviado con exito." +
+				`\n\n` +
+				`Puedes verla ahora en: https://discord.com/channels/${ctx.guildId}/${ctx.channelId}/${suggestion.id}`,
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,5 @@
+export const CONFIG = {
+	ROLES: {
+		EVERYONE: "",
+	},
+};

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,5 +1,9 @@
 export const CONFIG = {
 	ROLES: {
+		//Staff Roles
+		ADMIN: "",
+		// General Roles
 		EVERYONE: "",
+		
 	},
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,4 +5,7 @@ export const CONFIG = {
 		// General Roles
 		EVERYONE: "",
 	},
+	CHANNELS: {
+		SUGGESTIONS: "1486721405583364254",
+	},
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,6 +4,5 @@ export const CONFIG = {
 		ADMIN: "",
 		// General Roles
 		EVERYONE: "",
-		
 	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,18 @@
-import { Client, type ParseClient } from "seyfert";
+import { Client, type ParseClient, type ParseMiddlewares } from "seyfert";
+import type { CONFIG } from "./config/config";
+import { middlewares } from "./middlewares";
 
 async function boostrap() {
 	const client = new Client();
 
-	client.start().then(() =>
-		client.uploadCommands({
-			cachePath: "./commands.json",
-		}),
-	);
+	client.setServices({
+		middlewares: middlewares,
+	}),
+		client.start().then(() =>
+			client.uploadCommands({
+				cachePath: "./commands.json",
+			}),
+		);
 }
 
 boostrap().catch((error) => {
@@ -15,6 +20,15 @@ boostrap().catch((error) => {
 	process.exit(1);
 });
 
+type Roles = (typeof CONFIG.ROLES)[keyof typeof CONFIG.ROLES];
+
 declare module "seyfert" {
 	interface UsingClient extends ParseClient<Client<true>> {}
+
+	interface RegisteredMiddlewares
+		extends ParseMiddlewares<typeof middlewares> {}
+
+	interface ExtraProps {
+		requiredRoles?: Roles[];
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,13 @@ async function boostrap() {
 
 	client.setServices({
 		middlewares: middlewares,
-	}),
-		client.start().then(() =>
-			client.uploadCommands({
-				cachePath: "./commands.json",
-			}),
-		);
+	});
+
+	client.start().then(() =>
+		client.uploadCommands({
+			cachePath: "./commands.json",
+		}),
+	);
 }
 
 boostrap().catch((error) => {

--- a/src/middlewares/allowedRoles.ts
+++ b/src/middlewares/allowedRoles.ts
@@ -1,0 +1,29 @@
+import { createMiddleware } from "seyfert";
+import { CONFIG } from "../config/config";
+import { MessageFlags } from "seyfert/lib/types";
+import { Embeds } from "../utils/embeds";
+
+export const AuthMiddleware = createMiddleware<void>(async (middle) => {
+	const { context, next, stop } = middle;
+	const requiredRoles = context.command.props.requiredRoles;
+
+	if (!requiredRoles || requiredRoles.includes(CONFIG.ROLES.EVERYONE))
+		return next();
+
+	const userRoles = context.member?.roles.keys || [];
+
+	const hasPermission = requiredRoles.some((roleId) =>
+		userRoles.includes(roleId),
+	);
+
+	if (!hasPermission) {
+		await context.write({
+			embeds: [Embeds.noPermissionsEmbed()],
+			flags: MessageFlags.Ephemeral,
+		});
+
+		return stop(`No tiene los roles requeridos:  ${requiredRoles.join(", ")}`);
+	}
+
+	return next();
+});

--- a/src/middlewares/allowedRoles.ts
+++ b/src/middlewares/allowedRoles.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from "seyfert";
-import { CONFIG } from "../config/config";
 import { MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "../config/config";
 import { Embeds } from "../utils/embeds";
 
 export const AuthMiddleware = createMiddleware<void>(async (middle) => {

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,0 +1,5 @@
+import { AuthMiddleware } from "./allowedRoles";
+
+export const middlewares = {
+	auth: AuthMiddleware,
+};

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -1,0 +1,23 @@
+import { Embed } from "seyfert";
+
+export const Embeds = {
+	successEmbed(title: string, description?: string): Embed {
+		return new Embed()
+			.setTitle(title)
+			.setDescription(description)
+			.setColor("Green");
+	},
+	errorEmbed(title: string, description?: string): Embed {
+		return new Embed()
+			.setTitle(title)
+			.setDescription(description)
+			.setColor("Red");
+	},
+
+	noPermissionsEmbed(): Embed {
+		return new Embed()
+			.setColor("Red")
+			.setTitle("🚫 Acceso Denegado")
+			.setDescription("No tienes permiso para usar este comando.");
+	},
+};

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -1,4 +1,4 @@
-import { Embed } from "seyfert";
+import { type CommandContext, Embed } from "seyfert";
 
 export const Embeds = {
 	successEmbed(title: string, description?: string): Embed {
@@ -19,5 +19,22 @@ export const Embeds = {
 			.setColor("Red")
 			.setTitle("🚫 Acceso Denegado")
 			.setDescription("No tienes permiso para usar este comando.");
+	},
+
+	suggestionEmbed(ctx: CommandContext, suggestion: string): Embed {
+		return new Embed()
+			.setTitle(`**NUEVA SUGERENCIA**`)
+			.setThumbnail(ctx.author.avatarURL())
+			.setDescription(
+				`<@${ctx.author.id}> ha enviado una nueva sugerencia.` +
+					`\n\n` +
+					`**Sugerencia:**` +
+					`\n\n` +
+					`${suggestion}`,
+			)
+			.setAuthor({
+				name: "Sugerencia registrada con exito",
+				iconUrl: ctx.author.avatarURL(),
+			});
 	},
 };


### PR DESCRIPTION
Instead of hardcoding checks inside every command, we use a Middleware to intercept interactions, which reads the requiredRoles property from the command's extra properties and compares it against the user's current roles before execution; additionally, a new suggestion command has been implemented to allow users to create and submit their suggestions seamlessly through this same validated architecture.