### PR TITLE
feat: add bot user validation to commands

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   commands:
     biome-check:
       glob: "*.{ts,js,json,jsx,tsx}"
-      run: biome check --write --no-errors-on-unmatched {staged_files}
+      run: bunx --no biome check --write --no-errors-on-unmatched {staged_files}
       stage_fixed: true
 
 commit-msg:

--- a/src/commands/invites/invites.ts
+++ b/src/commands/invites/invites.ts
@@ -33,6 +33,15 @@ export default class InvitesCommand extends Command {
 		const guildId = ctx.guildId;
 		if (!guildId) return;
 
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed("Error", "Los bots no tienen invitaciones."),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		await ctx.deferReply(true);
 
 		const [dbInvites, joins] = await Promise.all([

--- a/src/commands/moderation/ban.ts
+++ b/src/commands/moderation/ban.ts
@@ -51,6 +51,18 @@ export default class BanCommand extends Command {
 
 		if (!guildId) return;
 
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"No podés realizar esta acción sobre un bot.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		await ctx.deferReply(true);
 
 		if (!(await validateModerationLimit(ctx, "ban"))) return;

--- a/src/commands/moderation/cases.ts
+++ b/src/commands/moderation/cases.ts
@@ -35,6 +35,15 @@ export default class CasesCommand extends Command {
 		const guildId = ctx.guildId;
 		if (!guildId) return;
 
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed("Error", "Los bots no tienen historial de casos."),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		await ctx.deferReply(true);
 
 		const allCases = await moderationService.getUserCases(usuario.id, guildId);

--- a/src/commands/moderation/kick.ts
+++ b/src/commands/moderation/kick.ts
@@ -51,6 +51,18 @@ export default class KickCommand extends Command {
 
 		if (!guildId) return;
 
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"No podés realizar esta acción sobre un bot.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		await ctx.deferReply(true);
 
 		if (!(await validateModerationLimit(ctx, "kick"))) return;

--- a/src/commands/moderation/mute.ts
+++ b/src/commands/moderation/mute.ts
@@ -64,6 +64,18 @@ export default class MuteCommand extends Command {
 		const guildId = ctx.guildId;
 		if (!guildId) return;
 
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"No podés realizar esta acción sobre un bot.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		const durationSeconds = parseDurationToSeconds(duracion);
 		if (durationSeconds === null) {
 			return ctx.editOrReply({

--- a/src/commands/moderation/restrict.ts
+++ b/src/commands/moderation/restrict.ts
@@ -65,6 +65,18 @@ export default class RestrictCommand extends Command {
 		const guildId = ctx.guildId;
 		if (!guildId) return;
 
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"No podés realizar esta acción sobre un bot.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		let durationSeconds: number | undefined;
 		if (duracion !== "0") {
 			const parsed = parseDurationToSeconds(duracion);

--- a/src/commands/moderation/warn.ts
+++ b/src/commands/moderation/warn.ts
@@ -51,6 +51,18 @@ export default class WarnCommand extends Command {
 
 		if (!guildId) return;
 
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"No podés realizar esta acción sobre un bot.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		await ctx.deferReply(true);
 
 		if (!(await validateModerationLimit(ctx, "warn"))) return;

--- a/src/commands/reputation/stats.ts
+++ b/src/commands/reputation/stats.ts
@@ -25,6 +25,14 @@ const options = {
 export default class StatsCommand extends Command {
 	override async run(ctx: CommandContext<typeof options>) {
 		const target = ctx.options.usuario ?? ctx.author;
+
+		if (ctx.options.usuario?.bot) {
+			return ctx.write({
+				embeds: [Embeds.errorEmbed("Error", "Los bots no tienen reputación.")],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
 		const points = await reputationRepository.getReputation(target.id);
 
 		const sortedTiers = [...CONFIG.REP_TIERS].sort(


### PR DESCRIPTION
Agrega validación de bots en todos los comandos que aceptan un parámetro de usuario.

- `/warn`, `/mute`, `/kick`, `/ban`, `/restrict` → no permiten ejecutar la acción sobre un bot
- `/cases` → los bots no tienen historial de casos
- `/invites` → los bots no tienen invitaciones
- `/stats` → los bots no tienen reputación
- `/add-rep` y `/remove-rep` ya tenían la validación

También corrige el hook de `lefthook.yml` que llamaba a `biome` como comando global en vez de usar `bunx`.