### PR TITLE
feat(cooldown): agregar claimRateLimitSlot para rate limit "N por ventana"

### DIFF
--- a/src/services/cooldown.ts
+++ b/src/services/cooldown.ts
@@ -27,6 +27,47 @@ export class CooldownService {
 	async cleanup() {
 		await cooldownRepository.deleteExpired(new Date());
 	}
+
+	/**
+	 * Rate limit estilo "N usos por ventana de Y segundos" usando slots
+	 * derivados de la key (`<key>:0`, `<key>:1`, ...). Cada slot ocupado
+	 * vive `windowSeconds`; cuando se liberan se reciclan automáticamente.
+	 *
+	 * Devuelve `{ ok: true }` si pudo reservar un slot, o
+	 * `{ ok: false, retryAfter }` con los segundos hasta que se libere
+	 * el slot más próximo.
+	 *
+	 * NOTA: hay una race condition acotada entre el read y el write — dos
+	 * requests concurrentes del mismo usuario podrían ambos reclamar el mismo
+	 * slot. En práctica el límite es bajo (Discord API + tiempo humano entre
+	 * mentions), pero si esto se vuelve crítico habría que mover a un upsert
+	 * atómico con check de conflicto.
+	 */
+	async claimRateLimitSlot(
+		userId: string,
+		key: string,
+		maxSlots: number,
+		windowSeconds: number,
+	): Promise<{ ok: true } | { ok: false; retryAfter: number }> {
+		// Lectura paralela de todos los slots — N round-trips bajan a 1
+		const slots = await Promise.all(
+			Array.from({ length: maxSlots }, (_, i) =>
+				this.getCooldown(userId, `${key}:${i}`),
+			),
+		);
+
+		const freeIndex = slots.findIndex((s) => !s);
+		if (freeIndex !== -1) {
+			await this.setCooldown(userId, `${key}:${freeIndex}`, windowSeconds);
+			return { ok: true };
+		}
+
+		const earliestExpiry = Math.min(
+			...slots.map((s) => s?.expiresAt.getTime() ?? Number.POSITIVE_INFINITY),
+		);
+		const retryAfter = Math.ceil((earliestExpiry - Date.now()) / 1000);
+		return { ok: false, retryAfter: Math.max(retryAfter, 1) };
+	}
 }
 
 export const cooldownService = new CooldownService();

--- a/src/services/cooldown.ts
+++ b/src/services/cooldown.ts
@@ -62,8 +62,14 @@ export class CooldownService {
 			return { ok: true };
 		}
 
+		// Si llegamos acá todos los slots están ocupados (findIndex devolvió -1),
+		// así que ningún elemento de slots es null. Filtramos por type-narrowing
+		// para no usar optional chaining engañoso en `.expiresAt.getTime()`.
+		const occupiedSlots = slots.filter(
+			(s): s is NonNullable<typeof s> => s !== null,
+		);
 		const earliestExpiry = Math.min(
-			...slots.map((s) => s?.expiresAt.getTime() ?? Number.POSITIVE_INFINITY),
+			...occupiedSlots.map((s) => s.expiresAt.getTime()),
 		);
 		const retryAfter = Math.ceil((earliestExpiry - Date.now()) / 1000);
 		return { ok: false, retryAfter: Math.max(retryAfter, 1) };


### PR DESCRIPTION
## Resumen

Agrega un método utility a `CooldownService` para hacer rate limiting tipo \"N usos por ventana de Y segundos\" sin tablas nuevas. Reusa la tabla `cooldowns` existente derivando slots de la key (`<key>:0`, `<key>:1`, ...). **Sin callers en este PR** — es infraestructura para un feature futuro.

## API

```ts
async claimRateLimitSlot(
  userId: string,
  key: string,
  maxSlots: number,
  windowSeconds: number,
): Promise<{ ok: true } | { ok: false; retryAfter: number }>
```

Uso:
```ts
const slot = await cooldownService.claimRateLimitSlot(userId, \"ai-research\", 2, 60);
if (slot.ok) {
  // procedo
} else {
  // esperá slot.retryAfter segundos
}
```

## Cómo funciona

- Cada slot es una key derivada (`<key>:0`, `<key>:1`, ..., `<key>:N-1`)
- Cuando un slot está libre se reserva por `windowSeconds`
- Cuando expira se libera independientemente → semántica de **sliding window**
- Lecturas paralelas con `Promise.all` (N round-trips → 1)

## Por qué no un counter

El schema `cooldowns` solo guarda `expiresAt` (no count). Derivar slots evita una migración. Cada slot tiene su propia ventana → comportamiento sliding window natural sin tracking adicional.

## Race condition acotada

Documentada en el JSDoc: dos requests concurrentes del mismo usuario podrían leer slot 0 vacío y ambos reclamarlo. En la práctica está bounded por velocidad humana entre interacciones (mentions a un bot, clicks de botón, etc.). Si se vuelve crítico habría que mover a un upsert atómico con check de conflicto — fuera de scope para este PR.

## Plan de pruebas

Sin callers todavía, así que el test es unitario manual:

```ts
// En un REPL o test:
await cooldownService.claimRateLimitSlot(\"user1\", \"test\", 2, 60); // → { ok: true }
await cooldownService.claimRateLimitSlot(\"user1\", \"test\", 2, 60); // → { ok: true }
await cooldownService.claimRateLimitSlot(\"user1\", \"test\", 2, 60); // → { ok: false, retryAfter: ~60 }

// Esperá 60s
await cooldownService.claimRateLimitSlot(\"user1\", \"test\", 2, 60); // → { ok: true }
```