### PR TITLE
fix(config): validar IDs de Discord en el boot

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,67 @@ export const CONFIG = {
 	},
 };
 
+const SNOWFLAKE_REGEX = /^\d{17,20}$/;
+
+const validateConfig = (): void => {
+	const errors: string[] = [];
+
+	const checkId = (path: string, value: string): void => {
+		if (!SNOWFLAKE_REGEX.test(value)) {
+			errors.push(`${path}: expected a 17-20 digit Discord ID, got "${value}"`);
+		}
+	};
+
+	checkId("GUILD_ID", CONFIG.GUILD_ID);
+	checkId("EMOJIS.PEPEDOWN", CONFIG.EMOJIS.PEPEDOWN);
+
+	for (const [key, value] of Object.entries(CONFIG.ROLES)) {
+		// EVERYONE is a sentinel: the auth middleware treats "" as a bypass.
+		if (key === "EVERYONE") {
+			if (value !== "") {
+				errors.push(
+					`ROLES.EVERYONE: must stay "" (auth bypass sentinel), got "${value}"`,
+				);
+			}
+			continue;
+		}
+		checkId(`ROLES.${key}`, value);
+	}
+
+	for (const [key, value] of Object.entries(CONFIG.RESTRICTIONS)) {
+		checkId(`RESTRICTIONS.${key}`, value);
+	}
+	for (const [key, value] of Object.entries(CONFIG.CHANNELS)) {
+		checkId(`CHANNELS.${key}`, value);
+	}
+	for (const [key, value] of Object.entries(CONFIG.CATEGORIES)) {
+		checkId(`CATEGORIES.${key}`, value);
+	}
+
+	CONFIG.AUTO_THREAD_CHANNELS.forEach((id, i) => {
+		checkId(`AUTO_THREAD_CHANNELS[${i}]`, id);
+	});
+	CONFIG.REP_TIERS.forEach((tier, i) => {
+		checkId(`REP_TIERS[${i}].roleId`, tier.roleId);
+	});
+	checkId("OTHER.DISBOARD_ID", CONFIG.OTHER.DISBOARD_ID);
+
+	// Each entry is either a custom emoji ID or a unicode emoji.
+	CONFIG.MEMES_REACTIONS.forEach((emoji, i) => {
+		if (!SNOWFLAKE_REGEX.test(emoji) && (!emoji || /^\d+$/.test(emoji))) {
+			errors.push(
+				`MEMES_REACTIONS[${i}]: expected a 17-20 digit emoji ID or a unicode emoji, got "${emoji}"`,
+			);
+		}
+	});
+
+	if (errors.length) {
+		throw new Error(`Invalid CONFIG values:\n${errors.join("\n")}`);
+	}
+};
+
+validateConfig();
+
 const Envscheme = z.object({
 	POSTGRES_URL: z.string(),
 	BOT_TOKEN: z.string(),


### PR DESCRIPTION
## Problema

Como describe el issue #42, los campos de `CONFIG` que quedan en string vacío (o con un ID mal copiado) no fallan en el boot: fallan silenciosamente en runtime, p. ej. comparar roles contra `""` siempre da `false`. Desde que se abrió el issue ya se llenaron los IDs reales en `main`, pero el riesgo de regresión sigue: nada impide que un campo nuevo quede vacío o con un ID inválido.

## Solución

Validación en import-time de `src/config.ts` (antes de la validación de env existente, mismo espíritu fail-fast): se verifica que cada ID sea un snowflake de 17-20 dígitos en `GUILD_ID`, `ROLES`, `CHANNELS`, `RESTRICTIONS`, `CATEGORIES`, `REP_TIERS[].roleId`, `AUTO_THREAD_CHANNELS`, `EMOJIS.PEPEDOWN` y `OTHER.DISBOARD_ID`. Si algo no valida, el bot tumba en el boot con un error que lista **todas** las rutas ofensivas de una vez.

Notas:
- `ROLES.EVERYONE` se valida como exactamente `""` porque el middleware de auth lo usa como sentinela de bypass — si alguien le pone un ID real, el boot falla con mensaje explícito.
- Los objetos se recorren con `Object.entries`, así que cualquier clave nueva queda validada automáticamente.
- `MEMES_REACTIONS` acepta IDs de emoji o emojis unicode no vacíos.
- No se cambió ningún valor de ID; `config.ts` sigue siendo módulo hoja.

Closes #42
