### PR TITLE
feat(forums): borrar el hilo cuando se borra el mensaje original del post

### DIFF
--- a/src/database/schemas/deletedForumPosts.ts
+++ b/src/database/schemas/deletedForumPosts.ts
@@ -1,0 +1,11 @@
+import { pgTable, serial, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const deletedForumPosts = pgTable("deleted_forum_posts", {
+	id: serial("id").primaryKey(),
+	threadId: varchar("thread_id", { length: 64 }).notNull(),
+	forumId: varchar("forum_id", { length: 64 }).notNull(),
+	// Nullable: unknown when the starter message author is not cached
+	authorId: varchar("author_id", { length: 64 }),
+	title: varchar("title", { length: 128 }).notNull(),
+	deletedAt: timestamp("deleted_at").defaultNow().notNull(),
+});

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -1,0 +1,49 @@
+import { createEvent } from "seyfert";
+import { CONFIG } from "@/config";
+import { deletedForumPostService } from "@/services/deletedForumPostService";
+import { Embeds } from "@/utils/embeds";
+
+export default createEvent({
+	data: { once: false, name: "messageDelete" },
+	async run(message, client) {
+		// In forum posts the starter message shares its id with the thread
+		if (message.id !== message.channelId) return;
+
+		const channel = await client.channels
+			.fetch(message.channelId)
+			.catch(() => null);
+		if (!channel?.isThread()) return;
+
+		const forum = await client.channels
+			.fetch(channel.parentId)
+			.catch(() => null);
+		if (!forum?.isForum()) return;
+
+		await client.channels
+			.delete(channel.id, {
+				reason: "Forum post starter message was deleted",
+			})
+			.catch((err) => console.error("Failed to delete forum thread:", err));
+
+		await deletedForumPostService.record({
+			threadId: channel.id,
+			forumId: forum.id,
+			authorId: channel.ownerId ?? null,
+			title: channel.name,
+		});
+
+		await client.messages
+			.write(CONFIG.CHANNELS.MOD_LOG, {
+				embeds: [
+					Embeds.forumPostDeletedEmbed({
+						title: channel.name,
+						forumName: forum.name,
+						authorId: channel.ownerId ?? null,
+					}),
+				],
+			})
+			.catch((err) =>
+				console.error("Failed to send forum post deletion log:", err),
+			);
+	},
+});

--- a/src/repositories/deletedForumPostRepository.ts
+++ b/src/repositories/deletedForumPostRepository.ts
@@ -1,0 +1,12 @@
+import { db } from "@/database";
+import { deletedForumPosts } from "@/database/schemas/deletedForumPosts";
+
+export type NewDeletedForumPost = typeof deletedForumPosts.$inferInsert;
+
+export class DeletedForumPostRepository {
+	public async create(post: NewDeletedForumPost) {
+		return await db.insert(deletedForumPosts).values(post);
+	}
+}
+
+export const deletedForumPostRepository = new DeletedForumPostRepository();

--- a/src/services/deletedForumPostService.ts
+++ b/src/services/deletedForumPostService.ts
@@ -1,0 +1,12 @@
+import {
+	deletedForumPostRepository,
+	type NewDeletedForumPost,
+} from "@/repositories/deletedForumPostRepository";
+
+export class DeletedForumPostService {
+	public async record(post: NewDeletedForumPost): Promise<void> {
+		await deletedForumPostRepository.create(post);
+	}
+}
+
+export const deletedForumPostService = new DeletedForumPostService();

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -206,6 +206,31 @@ export const Embeds = {
 			.setTimestamp();
 	},
 
+	forumPostDeletedEmbed(data: {
+		title: string;
+		forumName: string;
+		authorId: string | null;
+	}): Embed {
+		return new Embed()
+			.setTitle("Post de foro eliminado")
+			.setDescription(
+				"El mensaje original del post fue borrado, por lo que el hilo se eliminó automáticamente.",
+			)
+			.setColor("Red")
+			.addFields([
+				{ name: "Título", value: data.title, inline: false },
+				{ name: "Foro", value: data.forumName, inline: true },
+				{
+					name: "Autor",
+					value: data.authorId
+						? `<@${data.authorId}> (${data.authorId})`
+						: "Desconocido",
+					inline: true,
+				},
+			])
+			.setTimestamp();
+	},
+
 	modActionEmbed(data: {
 		caseId: number;
 		type: string;


### PR DESCRIPTION
## Qué hace

Cuando se borra el mensaje original (starter) de un post de foro —por spam o cualquier motivo—, el hilo quedaba huérfano. Este PR borra también el hilo y deja registro, como pide el issue.

## Cómo

- Nuevo evento `messageDelete`: en los posts de foro el ID del mensaje inicial es igual al ID del hilo (`message.id === message.channelId`), ese es el detector. Se hace fetch del canal y se verifica que sea un hilo cuyo padre es un canal de foro antes de borrar nada, así los hilos de canales de texto normales no se ven afectados.
- El borrado del hilo va con razón de auditoría; si el hilo ya no existe, degrada graceful (`.catch` por operación).
- Persistencia: tabla nueva `deleted_forum_posts` (hilo, foro, autor si está cacheado, título, fecha) vía service → repository, y embed al canal de mod-log.
- Borrar el hilo emite `threadDelete`, no `messageDelete`, así que no hay loops.

## Deploy

La tabla es nueva: requiere `bun run db:push` (el directorio `drizzle/` está gitignoreado en este repo, por eso no va migración en el PR).

Closes #52
