### PR TITLE
feat(moderation): control de publicidad repetida en canales de promoción

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,14 @@ export const CONFIG = {
 		"924436818718494740",
 		"1249222442199814257",
 	],
+	// Control de publicidad repetida en canales de autopromoción. Un usuario
+	// no puede volver a publicar contenido igual o muy similar en el mismo
+	// canal dentro de la ventana. Agregar acá otros canales de promo a vigilar.
+	AD_GUARD: {
+		CHANNELS: ["793661563705360394"] as string[], // JOBS_OFFERS
+		WINDOW_DAYS: 7,
+		SIMILARITY_THRESHOLD: 0.85,
+	},
 	REPUTATION_FOR_PRIORITY: 5,
 	ROLE_LIMITS: {
 		helper: { warn: -1, mute: 5, kick: 1, ban: 1, restrict: 1 },

--- a/src/database/schemas/adPosts.ts
+++ b/src/database/schemas/adPosts.ts
@@ -1,0 +1,10 @@
+import { pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const adPosts = pgTable("ad_posts", {
+	id: serial("id").primaryKey(),
+	userId: varchar("user_id", { length: 64 }).notNull(),
+	channelId: varchar("channel_id", { length: 64 }).notNull(),
+	contentHash: varchar("content_hash", { length: 64 }).notNull(),
+	normalizedContent: text("normalized_content").notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+});

--- a/src/events/messageCreate/adGuard.ts
+++ b/src/events/messageCreate/adGuard.ts
@@ -1,0 +1,92 @@
+import type { Message, UsingClient } from "seyfert";
+import { CONFIG } from "@/config";
+import { adGuardService } from "@/services/adGuardService";
+import { Embeds } from "@/utils/embeds";
+
+const NOTICE_DELETE_MS = 15_000;
+
+/**
+ * Control de publicidad repetida en canales de autopromoción
+ * (CONFIG.AD_GUARD.CHANNELS). Si el mensaje repite una publicación del
+ * mismo usuario en el mismo canal dentro de la ventana, lo borra y avisa
+ * por DM (o con un aviso efímero en el canal si tiene DMs cerrados) y
+ * devuelve true para cortar la cadena — un mensaje borrado no debe generar
+ * auto-thread. Si es publicación nueva la registra y devuelve false.
+ *
+ * Los nombres de los adjuntos entran al texto comparable para que reposts
+ * de solo imágenes con el mismo archivo sigan siendo detectables.
+ */
+export async function handleAdGuard(
+	message: Message,
+	client: UsingClient,
+): Promise<boolean> {
+	if (!CONFIG.AD_GUARD.CHANNELS.includes(message.channelId)) return false;
+
+	const attachmentNames = message.attachments
+		.map((att) => att.filename)
+		.join(" ");
+	const comparable = `${message.content ?? ""} ${attachmentNames}`.trim();
+	if (!comparable) return false;
+
+	const previous = await adGuardService.checkRepost(
+		message.author.id,
+		message.channelId,
+		comparable,
+	);
+
+	if (!previous) {
+		await adGuardService.recordPost(
+			message.author.id,
+			message.channelId,
+			comparable,
+		);
+		return false;
+	}
+
+	await message
+		.delete("Repeated self-promotion within the cooldown window")
+		.catch((err) => console.error("Failed to delete repeated ad:", err));
+
+	const retryTimestamp = Math.floor(
+		adGuardService.repostExpiresAt(previous.createdAt).getTime() / 1000,
+	);
+
+	await client.users
+		.createDM(message.author.id)
+		.then((dm) =>
+			dm.messages.write({
+				embeds: [
+					Embeds.adRepostDMEmbed({
+						channelId: message.channelId,
+						windowDays: CONFIG.AD_GUARD.WINDOW_DAYS,
+						retryTimestamp,
+					}),
+				],
+			}),
+		)
+		.catch(() => sendChannelNotice(message, client, retryTimestamp));
+
+	return true;
+}
+
+/** Fallback cuando el usuario tiene los DMs cerrados: aviso que se autoborra. */
+async function sendChannelNotice(
+	message: Message,
+	client: UsingClient,
+	retryTimestamp: number,
+) {
+	const notice = await client.messages
+		.write(message.channelId, {
+			content: `<@${message.author.id}> tu publicación fue eliminada por repetirse en los últimos ${CONFIG.AD_GUARD.WINDOW_DAYS} días. Podrás volver a publicarla <t:${retryTimestamp}:R>.`,
+			allowed_mentions: { users: [message.author.id] },
+		})
+		.catch((err) => {
+			console.error("Failed to send ad repost notice:", err);
+			return null;
+		});
+
+	if (!notice) return;
+	setTimeout(() => {
+		client.messages.delete(notice.id, message.channelId).catch(() => {});
+	}, NOTICE_DELETE_MS);
+}

--- a/src/events/messageCreate/index.ts
+++ b/src/events/messageCreate/index.ts
@@ -1,6 +1,7 @@
 import { createEvent } from "seyfert";
 import { CONFIG } from "@/config";
 import { bumpService } from "@/services/bumpService";
+import { handleAdGuard } from "./adGuard";
 import { handleAiMention } from "./aiMention";
 import { handleAutoThread } from "./autoThread";
 import { handleMemes } from "./memes";
@@ -15,7 +16,9 @@ import { handleThanks } from "./thanks";
  * `src/events/messageReactionAdd/`.
  *
  * - memes: aditivo (corre junto a los demás)
- * - autoThread / aiMention / thanks: mutuamente excluyentes. Devuelven
+ * - adGuard / autoThread / aiMention / thanks: mutuamente excluyentes.
+ *   adGuard corre antes que autoThread: un mensaje borrado por publicidad
+ *   repetida no debe generar thread. Devuelven
  *   `Promise<boolean>` indicando si manejaron el mensaje. Índex corta la
  *   cadena con `if (await handleX(...)) return;`.
  */
@@ -34,6 +37,7 @@ export default createEvent({
 		await handleMemes(message, client);
 
 		// Mutuamente excluyentes — el primero que aplique corta la cadena
+		if (await handleAdGuard(message, client)) return;
 		if (await handleAutoThread(message, client)) return;
 		if (await handleAiMention(message, client)) return;
 		await handleThanks(message, client);

--- a/src/events/messageUpdate/index.ts
+++ b/src/events/messageUpdate/index.ts
@@ -1,12 +1,12 @@
-import { createEvent } from "seyfert";
+import { createEvent, type Message } from "seyfert";
 import { handleWordCensor } from "../messageCreate/wordCensor";
 
 export default createEvent({
 	data: { once: false, name: "messageUpdate" },
-	async run(message, client) {
+	async run([message, _old], client) {
 		if (message.author?.bot) return;
 		if (!message.content) return;
 
-		await handleWordCensor(message, client);
+		await handleWordCensor(message as Message, client);
 	},
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Client, type ParseClient, type ParseMiddlewares } from "seyfert";
 import { CONFIG } from "./config";
 import { middlewares } from "./middlewares";
+import { adGuardService } from "./services/adGuardService";
 import { bumpService } from "./services/bumpService";
 import { cooldownService } from "./services/cooldown";
 import { moderationService } from "./services/moderationService";
@@ -28,11 +29,13 @@ async function boostrap() {
 		() => {
 			cooldownService.cleanup().catch(console.error);
 			moderationService.cleanupExpiredLimits().catch(console.error);
+			adGuardService.cleanup().catch(console.error);
 		},
 		1000 * 60 * 60,
 	);
 
 	await cooldownService.cleanup().catch(console.error);
+	await adGuardService.cleanup().catch(console.error);
 	await moderationService.cleanupExpiredLimits().catch(console.error);
 	await voiceRestrictService.recoverOnStartup(client).catch(console.error);
 	await bumpService.ensureBumpRole(client).catch(console.error);

--- a/src/repositories/adPostRepository.ts
+++ b/src/repositories/adPostRepository.ts
@@ -1,0 +1,37 @@
+import { and, eq, gte, lt } from "drizzle-orm";
+import { db } from "@/database";
+import { adPosts } from "@/database/schemas/adPosts";
+
+export class AdPostRepository {
+	async create(data: {
+		userId: string;
+		channelId: string;
+		contentHash: string;
+		normalizedContent: string;
+	}) {
+		return await db.insert(adPosts).values(data);
+	}
+
+	async findRecentByUserAndChannel(
+		userId: string,
+		channelId: string,
+		since: Date,
+	) {
+		return await db
+			.select()
+			.from(adPosts)
+			.where(
+				and(
+					eq(adPosts.userId, userId),
+					eq(adPosts.channelId, channelId),
+					gte(adPosts.createdAt, since),
+				),
+			);
+	}
+
+	async deleteOlderThan(date: Date) {
+		return await db.delete(adPosts).where(lt(adPosts.createdAt, date));
+	}
+}
+
+export const adPostRepository = new AdPostRepository();

--- a/src/services/adGuardService.ts
+++ b/src/services/adGuardService.ts
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { CONFIG } from "@/config";
+import { adPostRepository } from "@/repositories/adPostRepository";
+
+const WINDOW_MS = CONFIG.AD_GUARD.WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+export class AdGuardService {
+	/**
+	 * Normaliza el contenido para compararlo entre publicaciones: minúsculas,
+	 * sin URLs, menciones, emojis custom ni puntuación, con espacios
+	 * colapsados. Así dos avisos "iguales" con links o formato distinto
+	 * producen el mismo texto comparable.
+	 */
+	normalize(content: string): string {
+		return content
+			.toLowerCase()
+			.replace(/https?:\/\/\S+/g, " ")
+			.replace(/<a?:\w+:\d+>/g, " ")
+			.replace(/<(?:@[!&]?|#)\d+>/g, " ")
+			.replace(/[^\p{L}\p{N}\s]/gu, " ")
+			.replace(/\s+/g, " ")
+			.trim();
+	}
+
+	private hash(normalized: string): string {
+		return createHash("sha256").update(normalized).digest("hex");
+	}
+
+	private jaccardSimilarity(a: string, b: string): number {
+		const tokensA = new Set(a.split(" "));
+		const tokensB = new Set(b.split(" "));
+		if (!tokensA.size || !tokensB.size) return 0;
+
+		let intersection = 0;
+		for (const token of tokensA) {
+			if (tokensB.has(token)) intersection++;
+		}
+		const union = tokensA.size + tokensB.size - intersection;
+		return intersection / union;
+	}
+
+	/**
+	 * Busca publicaciones del usuario en el canal dentro de la ventana que
+	 * sean iguales (mismo hash) o muy similares (Jaccard sobre tokens >=
+	 * threshold). Devuelve el registro matcheado — su `createdAt` permite
+	 * avisarle al usuario cuándo puede volver a publicar — o null.
+	 */
+	async checkRepost(userId: string, channelId: string, content: string) {
+		const normalized = this.normalize(content);
+		if (!normalized) return null;
+
+		const contentHash = this.hash(normalized);
+		const since = new Date(Date.now() - WINDOW_MS);
+		const recent = await adPostRepository.findRecentByUserAndChannel(
+			userId,
+			channelId,
+			since,
+		);
+
+		return (
+			recent.find(
+				(post) =>
+					post.contentHash === contentHash ||
+					this.jaccardSimilarity(normalized, post.normalizedContent) >=
+						CONFIG.AD_GUARD.SIMILARITY_THRESHOLD,
+			) ?? null
+		);
+	}
+
+	async recordPost(userId: string, channelId: string, content: string) {
+		const normalized = this.normalize(content);
+		if (!normalized) return;
+
+		await adPostRepository.create({
+			userId,
+			channelId,
+			contentHash: this.hash(normalized),
+			normalizedContent: normalized,
+		});
+	}
+
+	repostExpiresAt(postCreatedAt: Date): Date {
+		return new Date(postCreatedAt.getTime() + WINDOW_MS);
+	}
+
+	async cleanup() {
+		await adPostRepository.deleteOlderThan(new Date(Date.now() - WINDOW_MS));
+	}
+}
+
+export const adGuardService = new AdGuardService();

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -186,7 +186,8 @@ export const Embeds = {
 			.setFooter({
 				text: "Si crees que esto fue un error, contacta al staff.",
 			})
-  }
+    },
+	
 	reportEmbed(data: {
 		reporterId: string;
 		reporterTag: string;

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -172,6 +172,23 @@ export const Embeds = {
 			.setTimestamp();
 	},
 
+	adRepostDMEmbed(data: {
+		channelId: string;
+		windowDays: number;
+		retryTimestamp: number;
+	}): Embed {
+		return new Embed()
+			.setTitle("Publicación repetida eliminada")
+			.setColor("Red")
+			.setDescription(
+				`Tu publicación en <#${data.channelId}> fue eliminada porque es igual o muy similar a una que ya publicaste en los últimos **${data.windowDays} días**.\n\nPodrás volver a publicarla <t:${data.retryTimestamp}:R>.`,
+			)
+			.setFooter({
+				text: "Si crees que esto fue un error, contacta al staff.",
+			})
+			.setTimestamp();
+	},
+
 	pingEmbed(latency: number): Embed {
 		return new Embed()
 			.setTitle(`**LATENCIA DEL BOT**`)

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -185,9 +185,9 @@ export const Embeds = {
 			)
 			.setFooter({
 				text: "Si crees que esto fue un error, contacta al staff.",
-			})
-    },
-	
+			});
+	},
+
 	reportEmbed(data: {
 		reporterId: string;
 		reporterTag: string;


### PR DESCRIPTION
## Qué hace

Recupera el control de publicidad repetida que tenía el bot anterior: en canales de promoción no se puede volver a publicar un mensaje igual o muy similar dentro de una ventana de 7 días.

## Cómo

- `CONFIG.AD_GUARD`: lista de canales vigilados (por ahora `JOBS_OFFERS`; se agregan más IDs ahí), ventana de 7 días y umbral de similitud — todo hardcodeado en config, sin tablas de configuración.
- Tabla `ad_posts` con el contenido normalizado + hash sha256 de cada publicación. La detección es por hash exacto o similitud Jaccard de tokens ≥ 0.85 sobre texto normalizado (minúsculas, sin URLs/menciones/emojis custom/puntuación), así que cambiar un par de palabras no evade el filtro.
- Sub-handler de `messageCreate` cableado **antes** de `autoThread`, para que un anuncio borrado no alcance a generar hilo.
- Al detectar repost: se borra el mensaje y se le explica al autor por DM (con `<t:...:R>` de cuándo puede volver a publicar); si tiene DMs cerrados, aviso breve en el canal que se autoborra.
- Limpieza horaria de registros viejos enganchada al interval existente en `index.ts`.

## Limitaciones conocidas

- Mensajes que son solo un link (sin texto) normalizan a vacío y no se comparan; mitigable a futuro conservando el hostname como token.
- Los adjuntos se comparan por nombre de archivo, no por contenido.

## Deploy

Tabla nueva: `bun run db:push` (`drizzle/` está gitignoreado, no va migración).

Closes #53
