### PR TITLE
feat(moderation): censura de palabras blacklisteadas

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,27 @@ export const CONFIG = {
 		MEMES: "783188322087993346",
 	},
 	MEMES_REACTIONS: ["796227219591921704", "♻️", "💤"] as string[],
+	CENSOR: {
+		// Palabras censuradas en cualquier canal. Escribirlas en minúsculas y
+		// sin acentos: el matching normaliza el mensaje (lowercase, sin
+		// acentos, leet básico) antes de comparar palabra por palabra.
+		WORDS: [
+			"maricon",
+			"maricones",
+			"marica",
+			"maricas",
+			"joto",
+			"jotos",
+			"sudaca",
+			"sudacas",
+			"gilipollas",
+			"subnormal",
+			"pendejo",
+			"pendeja",
+			"hijo de puta",
+			"hija de puta",
+		] as string[],
+	},
 	CATEGORIES: {
 		FORUMS: "1290372079279145092",
 	},

--- a/src/events/messageCreate/index.ts
+++ b/src/events/messageCreate/index.ts
@@ -5,6 +5,7 @@ import { handleAiMention } from "./aiMention";
 import { handleAutoThread } from "./autoThread";
 import { handleMemes } from "./memes";
 import { handleThanks } from "./thanks";
+import { handleWordCensor } from "./wordCensor";
 
 /**
  * Único handler de `messageCreate`. Seyfert almacena handlers como
@@ -14,6 +15,8 @@ import { handleThanks } from "./thanks";
  * sub-handlers en archivos hermanos, mismo patrón que
  * `src/events/messageReactionAdd/`.
  *
+ * - wordCensor: corre primero — un mensaje censurado se borra y no debe
+ *   disparar memes, threads, IA ni gracias
  * - memes: aditivo (corre junto a los demás)
  * - autoThread / aiMention / thanks: mutuamente excluyentes. Devuelven
  *   `Promise<boolean>` indicando si manejaron el mensaje. Índex corta la
@@ -29,6 +32,8 @@ export default createEvent({
 		}
 
 		if (message.author.bot) return;
+
+		if (await handleWordCensor(message, client)) return;
 
 		// Aditivo — corre y deja seguir la cadena
 		await handleMemes(message, client);

--- a/src/events/messageCreate/wordCensor.ts
+++ b/src/events/messageCreate/wordCensor.ts
@@ -1,0 +1,39 @@
+import type { Message, UsingClient } from "seyfert";
+import { CONFIG } from "@/config";
+import { censorService } from "@/services/censorService";
+
+/**
+ * Censura palabras blacklisteadas (CONFIG.CENSOR.WORDS): borra el mensaje
+ * original y lo repostea con las palabras reemplazadas por asteriscos vía
+ * un webhook que imita el nombre y avatar del autor (estilo NQN). Devuelve
+ * true si el mensaje fue censurado, para que index.ts corte la cadena.
+ */
+export async function handleWordCensor(
+	message: Message,
+	client: UsingClient,
+): Promise<boolean> {
+	if (!CONFIG.CENSOR.WORDS.length) return false;
+
+	const censored = censorService.censor(message.content ?? "");
+	if (!censored) return false;
+
+	const displayName = message.member?.displayName ?? message.author.username;
+
+	await message
+		.delete("Blacklisted word censored")
+		.catch((err) =>
+			console.error("Failed to delete blacklisted message:", err),
+		);
+
+	await censorService.repostAsUser(message, censored).catch(async (err) => {
+		console.error("Failed to repost censored message via webhook:", err);
+		// Fallback: que el contenido censurado no se pierda
+		await client.messages
+			.write(message.channelId, { content: `**${displayName}:** ${censored}` })
+			.catch((fallbackErr) =>
+				console.error("Failed to send censored fallback message:", fallbackErr),
+			);
+	});
+
+	return true;
+}

--- a/src/services/censorService.ts
+++ b/src/services/censorService.ts
@@ -1,0 +1,137 @@
+import type { Message, UsingClient } from "seyfert";
+import { CONFIG } from "@/config";
+
+const WEBHOOK_NAME = "Pingou";
+
+// Basic leet substitutions applied during normalization
+const LEET_CHARS: Record<string, string> = {
+	"0": "o",
+	"1": "i",
+	"3": "e",
+	"4": "a",
+	"5": "s",
+	"7": "t",
+};
+
+interface ChannelWebhook {
+	id: string;
+	token: string;
+}
+
+function escapeRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Builds a normalized copy of the text (lowercase, accents stripped, leet
+ * mapped) keeping an index map back to the original string, so matches on
+ * the normalized text can be censored over the original one.
+ */
+function buildNormalized(text: string): {
+	normalized: string;
+	indexMap: number[];
+} {
+	let normalized = "";
+	const indexMap: number[] = [];
+	for (let i = 0; i < text.length; i++) {
+		const stripped = text
+			.charAt(i)
+			.toLowerCase()
+			.normalize("NFD")
+			.replace(/[̀-ͯ]/g, "");
+		const mapped = LEET_CHARS[stripped] ?? stripped;
+		for (const char of mapped) {
+			normalized += char;
+			indexMap.push(i);
+		}
+	}
+	return { normalized, indexMap };
+}
+
+export class CensorService {
+	private webhookCache = new Map<string, ChannelWebhook>();
+	private _pattern: RegExp | null = null;
+
+	private get pattern(): RegExp | null {
+		if (!CONFIG.CENSOR.WORDS.length) return null;
+		if (!this._pattern) {
+			const alternatives = CONFIG.CENSOR.WORDS.map(escapeRegExp).join("|");
+			this._pattern = new RegExp(`\\b(?:${alternatives})\\b`, "g");
+		}
+		return this._pattern;
+	}
+
+	/**
+	 * Returns the content with every blacklisted word replaced by
+	 * backslash-escaped asterisks of the same length, or null when the
+	 * content has no blacklisted words.
+	 */
+	censor(content: string): string | null {
+		const pattern = this.pattern;
+		if (!pattern || !content) return null;
+
+		const { normalized, indexMap } = buildNormalized(content);
+		const matches = [...normalized.matchAll(pattern)];
+		if (!matches.length) return null;
+
+		let censored = content;
+		// Replace from the end so earlier indices stay valid
+		for (const match of matches.reverse()) {
+			const start = indexMap[match.index];
+			const last = indexMap[match.index + match[0].length - 1];
+			if (start === undefined || last === undefined) continue;
+			censored =
+				censored.slice(0, start) +
+				"\\*".repeat(last + 1 - start) +
+				censored.slice(last + 1);
+		}
+		return censored;
+	}
+
+	/** Reposts the censored content impersonating the original author. */
+	async repostAsUser(message: Message, content: string): Promise<void> {
+		const client = message.client;
+		const channel = await client.channels.fetch(message.channelId);
+		const isThread = channel.isThread();
+
+		// Webhooks cannot be created on threads: use the parent channel one
+		// executed with the thread_id query param
+		const webhookChannelId = isThread ? channel.parentId : message.channelId;
+		if (!webhookChannelId)
+			throw new Error(`Thread ${message.channelId} has no parent channel`);
+
+		const webhook = await this.getChannelWebhook(client, webhookChannelId);
+		await client.webhooks.writeMessage(webhook.id, webhook.token, {
+			body: {
+				content,
+				username: message.member?.displayName ?? message.author.username,
+				avatar_url: message.member?.avatarURL() ?? message.author.avatarURL(),
+				allowed_mentions: { parse: [] },
+			},
+			query: isThread ? { thread_id: message.channelId } : undefined,
+		});
+	}
+
+	private async getChannelWebhook(
+		client: UsingClient,
+		channelId: string,
+	): Promise<ChannelWebhook> {
+		const cached = this.webhookCache.get(channelId);
+		if (cached) return cached;
+
+		const existing = (await client.webhooks.listFromChannel(channelId)).find(
+			(hook) => hook.name === WEBHOOK_NAME && hook.token,
+		);
+		const webhook =
+			existing ??
+			(await client.webhooks.create(channelId, { name: WEBHOOK_NAME }));
+		if (!webhook.token)
+			throw new Error(`Webhook for channel ${channelId} has no token`);
+
+		const entry = { id: webhook.id, token: webhook.token };
+		this.webhookCache.set(channelId, entry);
+		return entry;
+	}
+}
+
+export const censorService = new CensorService();


### PR DESCRIPTION
## Qué hace

Censura de palabras blacklisteadas como propone el issue: en lugar de sancionar, se borra el mensaje y se repostea el contenido censurado vía webhook con el nombre y avatar del autor (mismo mecanismo que usa NQN con los emojis).

## Cómo

- `CONFIG.CENSOR.WORDS`: lista en config (sin DB, sin comandos de configuración). Va con una lista inicial de insultos claros; ajustarla es editar el array.
- El matching normaliza el mensaje (minúsculas, sin acentos vía NFD, leet básico 0/1/3/4/5/7) y compara palabra por palabra con word boundaries — `"MARICÓN"` y `"m4ric0n"` se detectan, pero no hay falsos positivos por substring. La censura se aplica sobre el texto **original**, reemplazando cada palabra por asteriscos escapados del mismo largo.
- Webhook "Pingou" get-or-create con caché por canal; en hilos se usa el webhook del canal padre con `thread_id`. El repost va con `allowed_mentions` vacío para no re-pingear.
- Si el webhook falla, fallback a mensaje plano `**<nombre>:** <texto censurado>` para no perder el contenido.

## Limitaciones

- Solo se repostea el texto: adjuntos/embeds/stickers/reply del original no se conservan (limitación de webhooks).
- La lista es exacta por palabra (con sus plurales listados); derivados no listados no se censuran — decisión deliberada para evitar falsos positivos.
- Permisos necesarios: `Manage Messages` y `Manage Webhooks`.

Closes #49
