### PR TITLE
feat(forums): mover un post de un foro a otro (/moverpost)

### DIFF
--- a/src/commands/moverpost.ts
+++ b/src/commands/moverpost.ts
@@ -1,0 +1,177 @@
+import {
+	ActionRow,
+	Button,
+	Command,
+	type CommandContext,
+	createChannelOption,
+	createStringOption,
+	Declare,
+	Options,
+} from "seyfert";
+import { ButtonStyle, ChannelType, MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { movePostService } from "@/services/movePostService";
+import { Embeds } from "@/utils/embeds";
+
+const options = {
+	foro: createChannelOption({
+		description: "Foro al que se moverá el post",
+		required: true,
+		channel_types: [ChannelType.GuildForum],
+	}),
+	motivo: createStringOption({
+		description: "Motivo del traslado",
+		required: true,
+		max_length: 512,
+	}),
+};
+
+const trustedRoles = [
+	CONFIG.ROLES.ADMIN,
+	CONFIG.ROLES.MODERATOR,
+	CONFIG.ROLES.HELPER,
+	...CONFIG.REP_TIERS.filter(
+		(tier) => tier.minPoints >= CONFIG.POST_MOVE.TRUST_MIN_REP_POINTS,
+	).map((tier) => tier.roleId),
+];
+
+@Declare({
+	name: "moverpost",
+	description: "Mueve este post a otro foro",
+})
+@Options(options)
+export default class MovePostCommand extends Command {
+	override async run(ctx: CommandContext<typeof options>) {
+		const { foro, motivo } = ctx.options;
+
+		const thread = await ctx.client.channels.fetch(ctx.channelId);
+		if (!thread.isThread()) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"Este comando solo puede usarse dentro de un post de foro.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const parent = await ctx.client.channels.fetch(thread.parentId);
+		if (!parent.isForum()) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"Este comando solo puede usarse dentro de un post de foro.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		if (foro.id === parent.id) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"El post ya está en ese foro. Elige un foro distinto.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		if (thread.ownerId === ctx.author.id) {
+			await ctx.deferReply(true);
+
+			const moved = await movePostService
+				.executeMove(ctx.client, {
+					threadId: thread.id,
+					threadName: thread.name,
+					sourceForumId: parent.id,
+					targetForumId: foro.id,
+					reason: motivo,
+					movedById: ctx.author.id,
+				})
+				.catch((err) => {
+					console.error("Failed to move post (owner path):", err);
+					return null;
+				});
+
+			if (!moved) {
+				return ctx.editResponse({
+					embeds: [
+						Embeds.errorEmbed(
+							"Error",
+							"No se pudo mover el post. Inténtalo de nuevo más tarde.",
+						),
+					],
+				});
+			}
+
+			// El hilo original ya no existe, la respuesta ephemeral puede fallar
+			return ctx
+				.editResponse({
+					embeds: [
+						Embeds.successEmbed(
+							"Post movido",
+							`Tu post ahora está en <#${moved.id}>.`,
+						),
+					],
+				})
+				.catch(() => {});
+		}
+
+		const memberRoles = ctx.member?.roles.keys ?? [];
+		if (!trustedRoles.some((role) => role && memberRoles.includes(role))) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Acceso denegado",
+						"Solo el autor del post, el staff o miembros con rango Veterano o superior pueden proponer mover un post.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const existing = await movePostService.getPending(thread.id);
+		if (existing) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Votación en curso",
+						"Ya hay una votación activa para mover este post.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		await movePostService.createPending({
+			threadId: thread.id,
+			targetForumId: foro.id,
+			reason: motivo,
+			initiatorId: ctx.author.id,
+		});
+
+		const button = new Button()
+			.setCustomId("move-post-vote")
+			.setLabel(`Votar a favor (0/${CONFIG.POST_MOVE.REQUIRED_VOTES})`)
+			.setStyle(ButtonStyle.Primary);
+
+		return ctx.write({
+			embeds: [
+				Embeds.postMoveVoteEmbed({
+					targetForumId: foro.id,
+					reason: motivo,
+					initiatorId: ctx.author.id,
+					votes: 0,
+					requiredVotes: CONFIG.POST_MOVE.REQUIRED_VOTES,
+				}),
+			],
+			components: [new ActionRow<Button>().setComponents([button])],
+		});
+	}
+}

--- a/src/components/movePostVoteButton.ts
+++ b/src/components/movePostVoteButton.ts
@@ -1,0 +1,148 @@
+import {
+	ActionRow,
+	Button,
+	ComponentCommand,
+	type ComponentContext,
+} from "seyfert";
+import { ButtonStyle, MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { type ExecuteMoveI, movePostService } from "@/services/movePostService";
+import { Embeds } from "@/utils/embeds";
+
+export default class MovePostVoteButton extends ComponentCommand {
+	override componentType = "Button" as const;
+
+	override filter(ctx: ComponentContext<typeof this.componentType>) {
+		return ctx.customId === "move-post-vote";
+	}
+
+	override async run(ctx: ComponentContext<typeof this.componentType>) {
+		const threadId = ctx.channelId;
+		const pending = await movePostService.getPending(threadId);
+
+		if (!pending) {
+			await ctx.interaction.message.edit({ components: [] }).catch(() => {});
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Votación expirada",
+						"Esta votación ya no está activa.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const thread = await ctx.client.channels.fetch(threadId).catch(() => null);
+		if (!thread?.isThread()) {
+			return movePostService.deletePending(threadId);
+		}
+
+		const moveData: ExecuteMoveI = {
+			threadId,
+			threadName: thread.name,
+			sourceForumId: thread.parentId,
+			targetForumId: pending.targetForumId,
+			reason: pending.reason,
+			movedById: pending.initiatorId,
+		};
+
+		// El autor del post aprueba el traslado con un solo voto
+		if (ctx.author.id === thread.ownerId) {
+			return this.executeMove(ctx, moveData);
+		}
+
+		if (ctx.author.id === pending.initiatorId) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Voto no permitido",
+						"Iniciaste esta votación, no puedes votar a tu propia propuesta.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		if (pending.voterIds.includes(ctx.author.id)) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed("Voto duplicado", "Ya votaste en esta propuesta."),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const updated = await movePostService.addVote(threadId, ctx.author.id);
+		if (!updated) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Voto no registrado",
+						"No se pudo registrar tu voto. Es posible que la votación ya no esté activa.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		if (updated.voterIds.length >= CONFIG.POST_MOVE.REQUIRED_VOTES) {
+			return this.executeMove(ctx, moveData);
+		}
+
+		await ctx.deferUpdate();
+
+		const button = new Button()
+			.setCustomId("move-post-vote")
+			.setLabel(
+				`Votar a favor (${updated.voterIds.length}/${CONFIG.POST_MOVE.REQUIRED_VOTES})`,
+			)
+			.setStyle(ButtonStyle.Primary);
+
+		return ctx.editResponse({
+			embeds: [
+				Embeds.postMoveVoteEmbed({
+					targetForumId: updated.targetForumId,
+					reason: updated.reason,
+					initiatorId: updated.initiatorId,
+					votes: updated.voterIds.length,
+					requiredVotes: CONFIG.POST_MOVE.REQUIRED_VOTES,
+				}),
+			],
+			components: [new ActionRow<Button>().setComponents([button])],
+		});
+	}
+
+	private async executeMove(
+		ctx: ComponentContext<typeof this.componentType>,
+		data: ExecuteMoveI,
+	) {
+		await ctx.deferUpdate();
+
+		// Reclama la fila pendiente: si otro click concurrente ya la borró,
+		// el traslado ya está en marcha y no debe ejecutarse dos veces
+		const claimed = await movePostService.deletePending(data.threadId);
+		if (!claimed.length) return;
+
+		const moved = await movePostService
+			.executeMove(ctx.client, data)
+			.catch((err) => {
+				console.error("Failed to move post (vote path):", err);
+				return null;
+			});
+
+		if (!moved) {
+			await ctx
+				.followup({
+					embeds: [
+						Embeds.errorEmbed(
+							"Error",
+							"No se pudo mover el post. Inténtalo de nuevo más tarde.",
+						),
+					],
+					flags: MessageFlags.Ephemeral,
+				})
+				.catch(() => {});
+		}
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,12 @@ export const CONFIG = {
 		mod: { warn: -1, mute: 10, kick: 5, ban: 2, restrict: 2 },
 		admin: { warn: -1, mute: -1, kick: -1, ban: -1, restrict: -1 },
 	},
+	POST_MOVE: {
+		REQUIRED_VOTES: 3,
+		EXPIRY_HOURS: 24,
+		// Rep tiers desde este puntaje (Veterano+) pueden iniciar votaciones
+		TRUST_MIN_REP_POINTS: 80,
+	},
 	REP_TIERS: [
 		{ minPoints: 1, roleId: "806755636288815115" }, // Iniciante
 		{ minPoints: 16, roleId: "805073774088945725" }, // Regular

--- a/src/database/schemas/pendingPostMoves.ts
+++ b/src/database/schemas/pendingPostMoves.ts
@@ -1,0 +1,10 @@
+import { pgTable, text, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const pendingPostMoves = pgTable("pending_post_moves", {
+	threadId: varchar("thread_id", { length: 64 }).primaryKey().notNull(),
+	targetForumId: varchar("target_forum_id", { length: 64 }).notNull(),
+	reason: varchar("reason", { length: 512 }).notNull(),
+	initiatorId: varchar("initiator_id", { length: 64 }).notNull(),
+	voterIds: text("voter_ids").array().notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { middlewares } from "./middlewares";
 import { bumpService } from "./services/bumpService";
 import { cooldownService } from "./services/cooldown";
 import { moderationService } from "./services/moderationService";
+import { movePostService } from "./services/movePostService";
 import { schedulerService } from "./services/scheduler";
 import { voiceRestrictService } from "./services/voiceRestrictService";
 
@@ -28,12 +29,14 @@ async function boostrap() {
 		() => {
 			cooldownService.cleanup().catch(console.error);
 			moderationService.cleanupExpiredLimits().catch(console.error);
+			movePostService.cleanupExpired().catch(console.error);
 		},
 		1000 * 60 * 60,
 	);
 
 	await cooldownService.cleanup().catch(console.error);
 	await moderationService.cleanupExpiredLimits().catch(console.error);
+	await movePostService.cleanupExpired().catch(console.error);
 	await voiceRestrictService.recoverOnStartup(client).catch(console.error);
 	await bumpService.ensureBumpRole(client).catch(console.error);
 	await schedulerService.recoverOnStartup(client).catch(console.error);

--- a/src/repositories/pendingPostMoveRepository.ts
+++ b/src/repositories/pendingPostMoveRepository.ts
@@ -1,0 +1,56 @@
+import { and, arrayContains, eq, lt, not, sql } from "drizzle-orm";
+import { db } from "@/database";
+import { pendingPostMoves } from "@/database/schemas/pendingPostMoves";
+
+interface Data {
+	threadId: string;
+	targetForumId: string;
+	reason: string;
+	initiatorId: string;
+}
+
+export class PendingPostMoveRepository {
+	async create(data: Data) {
+		return await db.insert(pendingPostMoves).values({ ...data, voterIds: [] });
+	}
+
+	async findByThreadId(threadId: string) {
+		const results = await db
+			.select()
+			.from(pendingPostMoves)
+			.where(eq(pendingPostMoves.threadId, threadId))
+			.limit(1);
+		return results[0];
+	}
+
+	async addVoter(threadId: string, voterId: string) {
+		const results = await db
+			.update(pendingPostMoves)
+			.set({
+				voterIds: sql`array_append(${pendingPostMoves.voterIds}, ${voterId})`,
+			})
+			.where(
+				and(
+					eq(pendingPostMoves.threadId, threadId),
+					not(arrayContains(pendingPostMoves.voterIds, [voterId])),
+				),
+			)
+			.returning();
+		return results[0];
+	}
+
+	async deleteByThreadId(threadId: string) {
+		return await db
+			.delete(pendingPostMoves)
+			.where(eq(pendingPostMoves.threadId, threadId))
+			.returning();
+	}
+
+	async deleteOlderThan(date: Date) {
+		return await db
+			.delete(pendingPostMoves)
+			.where(lt(pendingPostMoves.createdAt, date));
+	}
+}
+
+export const pendingPostMoveRepository = new PendingPostMoveRepository();

--- a/src/services/movePostService.ts
+++ b/src/services/movePostService.ts
@@ -1,0 +1,90 @@
+import type { UsingClient } from "seyfert";
+import { CONFIG } from "@/config";
+import { pendingPostMoveRepository } from "@/repositories/pendingPostMoveRepository";
+import { Embeds } from "@/utils/embeds";
+
+export interface ExecuteMoveI {
+	threadId: string;
+	threadName: string;
+	sourceForumId: string;
+	targetForumId: string;
+	reason: string;
+	movedById: string;
+}
+
+export class MovePostService {
+	async getPending(threadId: string) {
+		return await pendingPostMoveRepository.findByThreadId(threadId);
+	}
+
+	async createPending(data: {
+		threadId: string;
+		targetForumId: string;
+		reason: string;
+		initiatorId: string;
+	}) {
+		return await pendingPostMoveRepository.create(data);
+	}
+
+	async addVote(threadId: string, voterId: string) {
+		return await pendingPostMoveRepository.addVoter(threadId, voterId);
+	}
+
+	async deletePending(threadId: string) {
+		return await pendingPostMoveRepository.deleteByThreadId(threadId);
+	}
+
+	async cleanupExpired() {
+		const cutoff = new Date(
+			Date.now() - CONFIG.POST_MOVE.EXPIRY_HOURS * 60 * 60 * 1000,
+		);
+		return await pendingPostMoveRepository.deleteOlderThan(cutoff);
+	}
+
+	// Discord no permite mover hilos entre foros: recreamos el post en el
+	// foro destino (las respuestas no se migran) y borramos el original.
+	async executeMove(client: UsingClient, data: ExecuteMoveI) {
+		// El mensaje inicial de un post de foro comparte id con el hilo
+		const starter = await client.messages
+			.fetch(data.threadId, data.threadId)
+			.catch(() => null);
+
+		let content =
+			starter?.content ||
+			"*No se pudo recuperar el contenido original del post.*";
+		const attachmentUrls = starter?.attachments.map((a) => a.url) ?? [];
+		if (attachmentUrls.length) {
+			content += `\n${attachmentUrls.join("\n")}`;
+		}
+
+		const newThread = await client.channels.thread(
+			data.targetForumId,
+			{
+				name: data.threadName,
+				message: {
+					content: content.slice(0, 2000),
+					embeds: [
+						Embeds.postMovedEmbed({
+							sourceForumId: data.sourceForumId,
+							movedById: data.movedById,
+							reason: data.reason,
+						}),
+					],
+				},
+			},
+			"Post moved from another forum",
+		);
+
+		await client.channels
+			.delete(data.threadId, {
+				reason: `Post moved to forum ${data.targetForumId}`,
+			})
+			.catch((err) => console.error("Failed to delete original post:", err));
+
+		await pendingPostMoveRepository.deleteByThreadId(data.threadId);
+
+		return newThread;
+	}
+}
+
+export const movePostService = new MovePostService();

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -172,6 +172,48 @@ export const Embeds = {
 			.setTimestamp();
 	},
 
+	postMoveVoteEmbed(data: {
+		targetForumId: string;
+		reason: string;
+		initiatorId: string;
+		votes: number;
+		requiredVotes: number;
+	}): Embed {
+		return new Embed()
+			.setTitle("Votación para mover este post")
+			.setColor("Orange")
+			.setDescription(
+				`<@${data.initiatorId}> propone mover este post a <#${data.targetForumId}>.`,
+			)
+			.addFields([
+				{ name: "Motivo", value: data.reason, inline: false },
+				{
+					name: "Votos a favor",
+					value: `**${data.votes}** / ${data.requiredVotes}`,
+					inline: false,
+				},
+			])
+			.setFooter({
+				text: "El autor del post puede aprobar el traslado con un solo voto.",
+			})
+			.setTimestamp();
+	},
+
+	postMovedEmbed(data: {
+		sourceForumId: string;
+		movedById: string;
+		reason: string;
+	}): Embed {
+		return new Embed()
+			.setTitle("Post movido")
+			.setColor("Blue")
+			.setDescription(
+				`Este post fue movido desde <#${data.sourceForumId}> por <@${data.movedById}>.`,
+			)
+			.addFields([{ name: "Motivo", value: data.reason, inline: false }])
+			.setTimestamp();
+	},
+
 	pingEmbed(latency: number): Embed {
 		return new Embed()
 			.setTitle(`**LATENCIA DEL BOT**`)


### PR DESCRIPTION
## Qué hace

Implementa `/moverpost <foro> <motivo>` como pide el issue:

- El **dueño del post** lo mueve directo.
- Cualquier usuario con rol de confianza (Veterano o superior según `REP_TIERS`, o staff) puede **iniciar una votación**: con 3 votos a favor de otros usuarios distintos —o 1 voto del dueño— el post se mueve.

## Cómo

- Discord no permite mover hilos nativamente: el traslado recrea el post en el foro destino (título + contenido del mensaje inicial + URLs de adjuntos + embed indicando foro de origen, autor y motivo) y borra el original. Las respuestas del hilo **no** se migran — limitación inherente.
- Los roles de confianza se derivan de `CONFIG.REP_TIERS` (minPoints ≥ 80), sin duplicar IDs.
- Las votaciones sobreviven reinicios: tabla `pending_post_moves` con guard atómico contra doble voto (array_append + NOT arrayContains). El iniciador no puede votarse a sí mismo; el embed actualiza el conteo en vivo.
- Expiración de votaciones a las 24h, enganchada al cleanup horario existente.

## Limitaciones conocidas

- El post recreado pertenece al bot (el autor original deja de ser dueño del hilo nuevo).
- Las URLs de adjuntos de Discord son firmadas y expiran con el tiempo.
- Si el foro destino exige tags (`require_tag`), Discord rechaza la creación.

## Deploy

Tabla nueva: `bun run db:push` (`drizzle/` está gitignoreado).

Closes #51
