### PR TITLE
feat(roles): sistema de auto-roles config-driven

### DIFF
--- a/src/commands/autoroles.ts
+++ b/src/commands/autoroles.ts
@@ -1,0 +1,83 @@
+import {
+	ActionRow,
+	Command,
+	type CommandContext,
+	Declare,
+	Middlewares,
+	StringSelectMenu,
+	StringSelectOption,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { type AutoRoleCategory, CONFIG } from "@/config";
+import { Embeds } from "@/utils/embeds";
+
+function buildCategoryMenu(category: AutoRoleCategory): StringSelectMenu {
+	return new StringSelectMenu()
+		.setCustomId(`autoroles:${category.id}`)
+		.setPlaceholder("Selecciona tus roles")
+		.setValuesLength({ min: 0, max: category.roles.length })
+		.setOptions(
+			category.roles.map((role) => {
+				const option = new StringSelectOption()
+					.setLabel(role.label)
+					.setValue(role.roleId);
+				if (role.description) option.setDescription(role.description);
+				if (role.emoji) option.setEmoji(role.emoji);
+				return option;
+			}),
+		);
+}
+
+@Declare({
+	name: "autoroles",
+	description: "Publica los paneles de auto-roles en este canal",
+	props: {
+		requiredRoles: [CONFIG.ROLES.ADMIN],
+	},
+})
+@Middlewares(["auth"])
+export default class AutoRolesCommand extends Command {
+	override async run(ctx: CommandContext) {
+		if (!CONFIG.AUTO_ROLES.length) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Auto-roles",
+						"No hay categorías de auto-roles configuradas.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		await ctx.deferReply(true);
+
+		for (const category of CONFIG.AUTO_ROLES) {
+			const menuRow = new ActionRow<StringSelectMenu>().setComponents([
+				buildCategoryMenu(category),
+			]);
+
+			await ctx.client.messages
+				.write(ctx.channelId, {
+					embeds: [Embeds.autoRoleCategoryEmbed(category)],
+					components: [menuRow],
+				})
+				.catch((err) =>
+					console.error(
+						`Failed to post auto-roles panel for category ${category.id}:`,
+						err,
+					),
+				);
+		}
+
+		await ctx.editOrReply({
+			embeds: [
+				Embeds.successEmbed(
+					"Auto-roles",
+					"Los paneles de auto-roles se publicaron en este canal.",
+				),
+			],
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/components/autoRolesSelect.ts
+++ b/src/components/autoRolesSelect.ts
@@ -1,0 +1,70 @@
+import { ComponentCommand, type ComponentContext } from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { Embeds } from "@/utils/embeds";
+
+const CUSTOM_ID_PREFIX = "autoroles:";
+
+export default class AutoRolesSelect extends ComponentCommand {
+	override componentType = "StringSelect" as const;
+
+	override filter(ctx: ComponentContext<typeof this.componentType>) {
+		return ctx.customId.startsWith(CUSTOM_ID_PREFIX);
+	}
+
+	override async run(ctx: ComponentContext<typeof this.componentType>) {
+		const { guildId, member } = ctx;
+		if (!guildId || !member) return;
+
+		const categoryId = ctx.customId.slice(CUSTOM_ID_PREFIX.length);
+		const category = CONFIG.AUTO_ROLES.find((c) => c.id === categoryId);
+		if (!category) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Auto-roles",
+						"Esta categoría ya no está configurada.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		await ctx.deferReply(true);
+
+		const selected = new Set(ctx.interaction.values);
+		const memberRoles = member.roles.keys;
+
+		const added: string[] = [];
+		const removed: string[] = [];
+
+		for (const role of category.roles) {
+			const hasRole = memberRoles.includes(role.roleId);
+
+			if (selected.has(role.roleId) && !hasRole) {
+				const ok = await ctx.client.members
+					.addRole(guildId, ctx.author.id, role.roleId)
+					.then(() => true)
+					.catch((err) => {
+						console.error(`Failed to add auto-role ${role.roleId}:`, err);
+						return false;
+					});
+				if (ok) added.push(role.label);
+			} else if (!selected.has(role.roleId) && hasRole) {
+				const ok = await ctx.client.members
+					.removeRole(guildId, ctx.author.id, role.roleId)
+					.then(() => true)
+					.catch((err) => {
+						console.error(`Failed to remove auto-role ${role.roleId}:`, err);
+						return false;
+					});
+				if (ok) removed.push(role.label);
+			}
+		}
+
+		await ctx.editResponse({
+			embeds: [Embeds.autoRolesUpdatedEmbed({ added, removed })],
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,20 @@ export interface RoleLimits {
 	restrict: number;
 }
 
+export interface AutoRoleOption {
+	roleId: string;
+	label: string;
+	description?: string;
+	emoji?: string;
+}
+
+export interface AutoRoleCategory {
+	id: string;
+	title: string;
+	description: string;
+	roles: ReadonlyArray<AutoRoleOption>;
+}
+
 export const CONFIG = {
 	GUILD_ID: "768278151435386900",
 	EMOJIS: {
@@ -58,6 +72,9 @@ export const CONFIG = {
 		"1249222442199814257",
 	],
 	REPUTATION_FOR_PRIORITY: 5,
+	// Self-assignable roles posted with /autoroles. Each category becomes one
+	// embed + string select menu. Fill the role IDs from the #Roles channel.
+	AUTO_ROLES: [] as ReadonlyArray<AutoRoleCategory>,
 	ROLE_LIMITS: {
 		helper: { warn: -1, mute: 5, kick: 1, ban: 1, restrict: 1 },
 		mod: { warn: -1, mute: 10, kick: 5, ban: 2, restrict: 2 },

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -1,6 +1,6 @@
 import type { CompletionUsage } from "openai/resources";
 import { type CommandContext, Embed, type InMessageEmbed } from "seyfert";
-import { CONFIG } from "@/config";
+import { type AutoRoleCategory, CONFIG } from "@/config";
 import type { CreateRepLogI } from "@/services/reputationService";
 import { formatDurationForModEmbed } from "./duration";
 import type { SystemStats } from "./system";
@@ -170,6 +170,30 @@ export const Embeds = {
 				`La oferta de <@${userId}> ha sido rechazada por el staff.`,
 			)
 			.setTimestamp();
+	},
+
+	autoRoleCategoryEmbed(category: AutoRoleCategory): Embed {
+		return new Embed()
+			.setTitle(category.title)
+			.setDescription(category.description)
+			.setColor("Blurple");
+	},
+
+	autoRolesUpdatedEmbed(data: { added: string[]; removed: string[] }): Embed {
+		const lines: string[] = [];
+		if (data.added.length) {
+			lines.push(`**+${data.added.length}:** ${data.added.join(", ")}`);
+		}
+		if (data.removed.length) {
+			lines.push(`**-${data.removed.length}:** ${data.removed.join(", ")}`);
+		}
+
+		return new Embed()
+			.setTitle("Roles actualizados")
+			.setDescription(
+				lines.length ? lines.join("\n") : "No hubo cambios en tus roles.",
+			)
+			.setColor("Green");
 	},
 
 	pingEmbed(latency: number): Embed {


### PR DESCRIPTION
## Qué hace

Sistema de auto-roles config-driven: `/autoroles` (solo admin) publica en el canal actual un panel por categoría (embed + select menu) y los usuarios se ponen/quitan roles solos con semántica de toggle.

## Cómo

- `CONFIG.AUTO_ROLES`: categorías con sus roles, todo en `src/config.ts` (sin DB ni comandos de configuración, single-server). Cada categoría se vuelve un embed + string select con min 0 / max N.
- El handler agrega los roles seleccionados que faltan y quita los deseleccionados que el miembro tiene, con `.catch` por operación y resumen efímero (+N/−N).

## Nota importante

`CONFIG.AUTO_ROLES` va **vacío** en este PR porque los IDs reales de los roles de #Roles no son visibles desde fuera: hay que llenarlos al mergear (títulos/labels en español). Mientras esté vacío, `/autoroles` responde con error efímero. Restricciones de Discord: cada categoría admite de 1 a 25 roles (límite de los select menus). El bot necesita `Manage Roles` y estar por encima de los roles auto-asignables en la jerarquía.

Closes #2
