### PR TITLE
feat(tickets): sistema de tickets con hilos privados

### DIFF
--- a/src/commands/tickets/close.ts
+++ b/src/commands/tickets/close.ts
@@ -1,0 +1,79 @@
+import {
+	type CommandContext,
+	createStringOption,
+	Declare,
+	Options,
+	SubCommand,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { ticketService } from "@/services/ticketService";
+import { Embeds } from "@/utils/embeds";
+
+const options = {
+	motivo: createStringOption({
+		description: "Motivo del cierre",
+		required: false,
+		max_length: 500,
+	}),
+};
+
+const STAFF_ROLES = [
+	CONFIG.ROLES.ADMIN,
+	CONFIG.ROLES.MODERATOR,
+	CONFIG.ROLES.HELPER,
+];
+
+@Declare({
+	name: "close",
+	description: "Cierra el ticket actual",
+})
+@Options(options)
+export class TicketCloseCommand extends SubCommand {
+	override async run(ctx: CommandContext<typeof options>) {
+		const threadId = ctx.channelId;
+		if (!threadId) return;
+
+		const ticket = await ticketService.getOpenTicketByThread(threadId);
+		if (!ticket) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"Este comando solo puede usarse dentro de un ticket abierto.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const userRoles = ctx.member?.roles.keys ?? [];
+		const isStaff = STAFF_ROLES.some((roleId) => userRoles.includes(roleId));
+		if (ticket.userId !== ctx.author.id && !isStaff) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Error",
+						"Solo quien abrió el ticket o el staff pueden cerrarlo.",
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		await ticketService.closeTicket(threadId, ctx.author.id);
+
+		await ctx.write({
+			embeds: [
+				Embeds.ticketClosedEmbed({
+					closedBy: ctx.author.id,
+					reason: ctx.options.motivo,
+				}),
+			],
+		});
+
+		await ctx.client.channels
+			.edit(threadId, { locked: true, archived: true })
+			.catch((err) => console.error("Failed to lock ticket thread:", err));
+	}
+}

--- a/src/commands/tickets/setup.ts
+++ b/src/commands/tickets/setup.ts
@@ -1,0 +1,47 @@
+import {
+	ActionRow,
+	Button,
+	type CommandContext,
+	Declare,
+	Middlewares,
+	SubCommand,
+} from "seyfert";
+import { ButtonStyle, MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { Embeds } from "@/utils/embeds";
+
+@Declare({
+	name: "setup",
+	description: "Publica el panel para abrir tickets en este canal",
+	props: {
+		requiredRoles: [CONFIG.ROLES.ADMIN],
+	},
+})
+@Middlewares(["auth"])
+export class TicketSetupCommand extends SubCommand {
+	override async run(ctx: CommandContext) {
+		const channelId = ctx.channelId;
+		if (!channelId) return;
+
+		const button = new Button()
+			.setCustomId("ticket:open")
+			.setEmoji("🎫")
+			.setLabel("Crear ticket")
+			.setStyle(ButtonStyle.Primary);
+
+		await ctx.client.messages.write(channelId, {
+			embeds: [Embeds.ticketPanelEmbed()],
+			components: [new ActionRow<Button>().setComponents([button])],
+		});
+
+		return ctx.write({
+			embeds: [
+				Embeds.successEmbed(
+					"Panel publicado",
+					"El panel de tickets fue publicado en este canal.",
+				),
+			],
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/commands/tickets/ticket.ts
+++ b/src/commands/tickets/ticket.ts
@@ -1,0 +1,10 @@
+import { Command, Declare, Options } from "seyfert";
+import { TicketCloseCommand } from "./close";
+import { TicketSetupCommand } from "./setup";
+
+@Declare({
+	name: "ticket",
+	description: "Sistema de tickets de soporte",
+})
+@Options([TicketSetupCommand, TicketCloseCommand])
+export default class TicketCommand extends Command {}

--- a/src/components/ticketModal.ts
+++ b/src/components/ticketModal.ts
@@ -1,0 +1,78 @@
+import { ModalCommand, type ModalContext } from "seyfert";
+import { ChannelType } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { ticketService } from "@/services/ticketService";
+import { Embeds } from "@/utils/embeds";
+
+export default class TicketModal extends ModalCommand {
+	override filter(ctx: ModalContext) {
+		return ctx.customId === "ticket:modal";
+	}
+
+	override async run(ctx: ModalContext) {
+		const subject = ctx.interaction.getInputValue("subject", true) as string;
+		const description = ctx.interaction.getInputValue("description", false) as
+			| string
+			| undefined;
+
+		const channelId = ctx.channelId;
+		if (!channelId) return;
+
+		await ctx.deferReply(true);
+
+		const thread = await ctx.client.channels.thread(channelId, {
+			name: `ticket-${ctx.author.username}`,
+			type: ChannelType.PrivateThread,
+			invitable: false,
+			auto_archive_duration: 10080,
+		});
+
+		const result = await ticketService.openTicket({
+			userId: ctx.author.id,
+			threadId: thread.id,
+			subject,
+		});
+
+		if (!result.created) {
+			await ctx.client.channels
+				.delete(thread.id)
+				.catch((err) =>
+					console.error("Failed to delete duplicate ticket thread:", err),
+				);
+			return ctx.editOrReply({
+				embeds: [
+					Embeds.errorEmbed(
+						"Ya tienes un ticket abierto",
+						`Puedes continuar la conversación en <#${result.existing.threadId}>.`,
+					),
+				],
+			});
+		}
+
+		// El bot tiene allowedMentions.parse [] global (src/index.ts) — sin este
+		// override explícito ni el usuario ni el staff recibirían el ping.
+		await ctx.client.messages.write(thread.id, {
+			content: `<@${ctx.author.id}> <@&${CONFIG.ROLES.MODERATOR}>`,
+			embeds: [
+				Embeds.ticketOpenedEmbed({
+					userId: ctx.author.id,
+					subject,
+					description,
+				}),
+			],
+			allowed_mentions: {
+				users: [ctx.author.id],
+				roles: [CONFIG.ROLES.MODERATOR],
+			},
+		});
+
+		return ctx.editOrReply({
+			embeds: [
+				Embeds.successEmbed(
+					"Ticket creado",
+					`Tu ticket fue creado en <#${thread.id}>.`,
+				),
+			],
+		});
+	}
+}

--- a/src/components/ticketOpenButton.ts
+++ b/src/components/ticketOpenButton.ts
@@ -1,0 +1,61 @@
+import {
+	ComponentCommand,
+	type ComponentContext,
+	Label,
+	Modal,
+	TextInput,
+} from "seyfert";
+import { MessageFlags, TextInputStyle } from "seyfert/lib/types";
+import { ticketService } from "@/services/ticketService";
+import { Embeds } from "@/utils/embeds";
+
+export default class TicketOpenButton extends ComponentCommand {
+	override componentType = "Button" as const;
+
+	override filter(ctx: ComponentContext<typeof this.componentType>) {
+		return ctx.customId === "ticket:open";
+	}
+
+	override async run(ctx: ComponentContext<typeof this.componentType>) {
+		const existing = await ticketService.getOpenTicketByUser(ctx.author.id);
+		if (existing) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Ya tienes un ticket abierto",
+						`Puedes continuar la conversación en <#${existing.threadId}>.`,
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const modal = new Modal()
+			.setCustomId("ticket:modal")
+			.setTitle("Nuevo ticket de soporte")
+			.setComponents([
+				new Label()
+					.setLabel("Asunto")
+					.setComponent(
+						new TextInput()
+							.setCustomId("subject")
+							.setPlaceholder("Resume tu problema en una línea")
+							.setStyle(TextInputStyle.Short)
+							.setLength({ max: 255 })
+							.setRequired(true),
+					),
+				new Label()
+					.setLabel("Descripción")
+					.setComponent(
+						new TextInput()
+							.setCustomId("description")
+							.setPlaceholder("Cuéntanos más detalles (opcional)")
+							.setStyle(TextInputStyle.Paragraph)
+							.setLength({ max: 1024 })
+							.setRequired(false),
+					),
+			]);
+
+		return ctx.interaction.modal(modal);
+	}
+}

--- a/src/database/schemas/tickets.ts
+++ b/src/database/schemas/tickets.ts
@@ -1,0 +1,12 @@
+import { pgTable, serial, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const tickets = pgTable("tickets", {
+	id: serial("id").primaryKey(),
+	userId: varchar("user_id", { length: 64 }).notNull(),
+	threadId: varchar("thread_id", { length: 64 }).notNull().unique(),
+	subject: varchar("subject", { length: 255 }).notNull(),
+	status: varchar("status", { length: 16 }).default("open").notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	closedAt: timestamp("closed_at"),
+	closedBy: varchar("closed_by", { length: 64 }),
+});

--- a/src/repositories/ticketRepository.ts
+++ b/src/repositories/ticketRepository.ts
@@ -1,0 +1,37 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/database";
+import { tickets } from "@/database/schemas/tickets";
+
+export class TicketRepository {
+	async create(data: { userId: string; threadId: string; subject: string }) {
+		const results = await db.insert(tickets).values(data).returning();
+		return results[0];
+	}
+
+	async findOpenByUser(userId: string) {
+		const results = await db
+			.select()
+			.from(tickets)
+			.where(and(eq(tickets.userId, userId), eq(tickets.status, "open")))
+			.limit(1);
+		return results[0];
+	}
+
+	async findOpenByThread(threadId: string) {
+		const results = await db
+			.select()
+			.from(tickets)
+			.where(and(eq(tickets.threadId, threadId), eq(tickets.status, "open")))
+			.limit(1);
+		return results[0];
+	}
+
+	async close(threadId: string, closedBy: string) {
+		return await db
+			.update(tickets)
+			.set({ status: "closed", closedAt: new Date(), closedBy })
+			.where(eq(tickets.threadId, threadId));
+	}
+}
+
+export const ticketRepository = new TicketRepository();

--- a/src/services/ticketService.ts
+++ b/src/services/ticketService.ts
@@ -1,0 +1,37 @@
+import { ticketRepository } from "@/repositories/ticketRepository";
+
+type Ticket = NonNullable<
+	Awaited<ReturnType<typeof ticketRepository.findOpenByUser>>
+>;
+
+export type OpenTicketResult =
+	| { created: true; ticket: Ticket | undefined }
+	| { created: false; existing: Ticket };
+
+export class TicketService {
+	async getOpenTicketByUser(userId: string) {
+		return await ticketRepository.findOpenByUser(userId);
+	}
+
+	async getOpenTicketByThread(threadId: string) {
+		return await ticketRepository.findOpenByThread(threadId);
+	}
+
+	async openTicket(data: {
+		userId: string;
+		threadId: string;
+		subject: string;
+	}): Promise<OpenTicketResult> {
+		const existing = await ticketRepository.findOpenByUser(data.userId);
+		if (existing) return { created: false, existing };
+
+		const ticket = await ticketRepository.create(data);
+		return { created: true, ticket };
+	}
+
+	async closeTicket(threadId: string, closedBy: string) {
+		return await ticketRepository.close(threadId, closedBy);
+	}
+}
+
+export const ticketService = new TicketService();

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -773,6 +773,51 @@ export const Embeds = {
 			.setTimestamp();
 	},
 
+	ticketPanelEmbed(): Embed {
+		return new Embed()
+			.setTitle("Soporte — abre un ticket")
+			.setDescription(
+				"¿Necesitas ayuda del staff o quieres reportar algo de forma privada?\n\nPulsa el botón de abajo para abrir un ticket. Se creará un hilo privado donde solo tú y el staff podrán hablar.",
+			)
+			.setColor("Blue")
+			.setFooter({ text: "Solo puedes tener un ticket abierto a la vez." });
+	},
+
+	ticketOpenedEmbed(data: {
+		userId: string;
+		subject: string;
+		description?: string;
+	}): Embed {
+		const fields = [{ name: "Asunto", value: data.subject, inline: false }];
+
+		if (data.description) {
+			fields.push({
+				name: "Descripción",
+				value: data.description.slice(0, 1024),
+				inline: false,
+			});
+		}
+
+		return new Embed()
+			.setTitle("Nuevo ticket")
+			.setDescription(
+				`Ticket abierto por <@${data.userId}>. El staff te atenderá en breve.\n\nCuando el problema esté resuelto, usa \`/ticket close\` para cerrarlo.`,
+			)
+			.setColor("Blue")
+			.addFields(fields)
+			.setTimestamp();
+	},
+
+	ticketClosedEmbed(data: { closedBy: string; reason?: string }): Embed {
+		return new Embed()
+			.setTitle("Ticket cerrado")
+			.setDescription(
+				`Este ticket fue cerrado por <@${data.closedBy}>.${data.reason ? `\n**Motivo:** ${data.reason}` : ""}`,
+			)
+			.setColor("Red")
+			.setTimestamp();
+	},
+
 	topNegativeEmbed(data: {
 		users: Array<{ userId: string; points: number }>;
 		period: string;


### PR DESCRIPTION
## Qué hace

Sistema de tickets MVP:

- `/ticket setup` (admin): publica el panel con botón "🎫 Crear ticket" en el canal actual.
- Botón → modal (asunto + descripción opcional) → se crea un **hilo privado** `ticket-<usuario>` en el canal del panel, con mención al usuario y al rol de moderación (allowed_mentions explícito, porque el cliente global usa `parse: []`).
- `/ticket close [motivo]` (dueño del ticket o staff, dentro del hilo): marca el ticket cerrado en DB, manda embed de cierre y bloquea + archiva el hilo.
- Regla de 1 ticket abierto por usuario (con link al existente si intenta abrir otro).

## Cómo

- Tabla `tickets` (usuario, hilo, asunto, estado, fechas, quién cerró) + repository + service; el resto sigue el layering del repo.
- Los tickets cerrados se archivan, no se borran: queda el historial y el usuario puede abrir uno nuevo.

## Deploy

- Tabla nueva: `bun run db:push` (`drizzle/` gitignoreado).
- El panel debe publicarse en un canal de texto donde el bot tenga `Create Private Threads` / `Manage Threads`.

Closes #18
