### PR TITLE
feat(voice): puntos por actividad en canales de voz

### DIFF
--- a/src/commands/voice/stats.ts
+++ b/src/commands/voice/stats.ts
@@ -1,0 +1,52 @@
+import {
+	type CommandContext,
+	createUserOption,
+	Declare,
+	Options,
+	SubCommand,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { voiceActivityService } from "@/services/voiceActivityService";
+import { Embeds } from "@/utils/embeds";
+
+const options = {
+	usuario: createUserOption({
+		description: "Usuario del que ver la actividad (por defecto, tú mismo)",
+		required: false,
+	}),
+};
+
+@Declare({
+	name: "stats",
+	description: "Ve tus puntos y horas en canales de voz, o los de otro usuario",
+})
+@Options(options)
+export class VoiceStatsCommand extends SubCommand {
+	override async run(ctx: CommandContext<typeof options>) {
+		const target = ctx.options.usuario ?? ctx.author;
+
+		if (ctx.options.usuario?.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed("Error", "Los bots no acumulan actividad de voz."),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const stats = await voiceActivityService.getStats(target.id);
+
+		await ctx.write({
+			embeds: [
+				Embeds.voiceStatsEmbed({
+					userId: target.id,
+					username: target.username,
+					avatarUrl: target.avatarURL(),
+					points: stats.points,
+					totalMinutes: stats.totalMinutes,
+				}),
+			],
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/commands/voice/top.ts
+++ b/src/commands/voice/top.ts
@@ -1,0 +1,27 @@
+import { type CommandContext, Declare, SubCommand } from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { voiceActivityService } from "@/services/voiceActivityService";
+import { Embeds } from "@/utils/embeds";
+
+@Declare({
+	name: "top",
+	description: "Muestra el top de usuarios con más actividad en voz",
+})
+export class VoiceTopCommand extends SubCommand {
+	override async run(ctx: CommandContext) {
+		const topUsers = await voiceActivityService.getTop(10);
+
+		await ctx.write({
+			embeds: [
+				Embeds.voiceTopEmbed({
+					users: topUsers.map((u) => ({
+						userId: u.userId,
+						points: u.points,
+						totalMinutes: u.totalMinutes,
+					})),
+				}),
+			],
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/commands/voice/voz.ts
+++ b/src/commands/voice/voz.ts
@@ -1,0 +1,10 @@
+import { Command, Declare, Options } from "seyfert";
+import { VoiceStatsCommand } from "./stats";
+import { VoiceTopCommand } from "./top";
+
+@Declare({
+	name: "voz",
+	description: "Puntos por actividad en canales de voz",
+})
+@Options([VoiceStatsCommand, VoiceTopCommand])
+export default class VozCommand extends Command {}

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,10 @@ export const CONFIG = {
 		mod: { warn: -1, mute: 10, kick: 5, ban: 2, restrict: 2 },
 		admin: { warn: -1, mute: -1, kick: -1, ban: -1, restrict: -1 },
 	},
+	VOICE_ACTIVITY: {
+		MINUTES_PER_POINT: 10,
+		MIN_HUMANS: 2,
+	},
 	REP_TIERS: [
 		{ minPoints: 1, roleId: "806755636288815115" }, // Iniciante
 		{ minPoints: 16, roleId: "805073774088945725" }, // Regular

--- a/src/database/schemas/voiceActivity.ts
+++ b/src/database/schemas/voiceActivity.ts
@@ -1,0 +1,7 @@
+import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+
+export const voiceActivity = pgTable("voice_activity", {
+	userId: varchar("user_id", { length: 64 }).primaryKey().notNull(),
+	points: integer("points").default(0).notNull(),
+	totalMinutes: integer("total_minutes").default(0).notNull(),
+});

--- a/src/database/schemas/voiceSessions.ts
+++ b/src/database/schemas/voiceSessions.ts
@@ -1,0 +1,8 @@
+import { pgTable, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const voiceSessions = pgTable("voice_sessions", {
+	userId: varchar("user_id", { length: 64 }).primaryKey().notNull(),
+	channelId: varchar("channel_id", { length: 64 }).notNull(),
+	joinedAt: timestamp("joined_at").notNull(),
+	lastAwardedAt: timestamp("last_awarded_at").notNull(),
+});

--- a/src/events/voiceStateUpdate.ts
+++ b/src/events/voiceStateUpdate.ts
@@ -1,0 +1,20 @@
+import { createEvent } from "seyfert";
+import { voiceActivityService } from "@/services/voiceActivityService";
+
+export default createEvent({
+	data: { once: false, name: "voiceStateUpdate" },
+	async run([state, oldState]) {
+		// Same channel means a mute/deaf/stream toggle — not a session boundary
+		if (state.channelId === oldState?.channelId) return;
+
+		const user = await state.user().catch(() => null);
+		if (!user || user.bot) return;
+
+		if (state.channelId) {
+			// Join or move — upsert restarts tracking on the new channel
+			await voiceActivityService.startSession(state.userId, state.channelId);
+		} else {
+			await voiceActivityService.endSession(state.userId);
+		}
+	},
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { bumpService } from "./services/bumpService";
 import { cooldownService } from "./services/cooldown";
 import { moderationService } from "./services/moderationService";
 import { schedulerService } from "./services/scheduler";
+import { voiceActivityService } from "./services/voiceActivityService";
 import { voiceRestrictService } from "./services/voiceRestrictService";
 
 async function boostrap() {
@@ -32,9 +33,17 @@ async function boostrap() {
 		1000 * 60 * 60,
 	);
 
+	setInterval(
+		() => {
+			voiceActivityService.runAwardCycle(client).catch(console.error);
+		},
+		1000 * 60 * 5,
+	);
+
 	await cooldownService.cleanup().catch(console.error);
 	await moderationService.cleanupExpiredLimits().catch(console.error);
 	await voiceRestrictService.recoverOnStartup(client).catch(console.error);
+	await voiceActivityService.recoverOnStartup(client).catch(console.error);
 	await bumpService.ensureBumpRole(client).catch(console.error);
 	await schedulerService.recoverOnStartup(client).catch(console.error);
 }

--- a/src/repositories/voiceActivityRepository.ts
+++ b/src/repositories/voiceActivityRepository.ts
@@ -1,0 +1,43 @@
+import { desc, eq, sql } from "drizzle-orm";
+import { db } from "@/database";
+import { voiceActivity } from "@/database/schemas/voiceActivity";
+
+export class VoiceActivityRepository {
+	// Awards 1 point each time total_minutes crosses a multiple of
+	// minutesPerPoint, so the remainder carries over between cycles.
+	async addMinutes(userId: string, minutes: number, minutesPerPoint: number) {
+		await db
+			.insert(voiceActivity)
+			.values({
+				userId,
+				points: Math.floor(minutes / minutesPerPoint),
+				totalMinutes: minutes,
+			})
+			.onConflictDoUpdate({
+				target: voiceActivity.userId,
+				set: {
+					points: sql`${voiceActivity.points} + (${voiceActivity.totalMinutes} + ${minutes}) / ${minutesPerPoint} - ${voiceActivity.totalMinutes} / ${minutesPerPoint}`,
+					totalMinutes: sql`${voiceActivity.totalMinutes} + ${minutes}`,
+				},
+			});
+	}
+
+	async findByUserId(userId: string) {
+		const result = await db
+			.select()
+			.from(voiceActivity)
+			.where(eq(voiceActivity.userId, userId))
+			.limit(1);
+		return result[0] ?? { userId, points: 0, totalMinutes: 0 };
+	}
+
+	async getTop(limit = 10) {
+		return await db
+			.select()
+			.from(voiceActivity)
+			.orderBy(desc(voiceActivity.points))
+			.limit(limit);
+	}
+}
+
+export const voiceActivityRepository = new VoiceActivityRepository();

--- a/src/repositories/voiceSessionRepository.ts
+++ b/src/repositories/voiceSessionRepository.ts
@@ -1,0 +1,32 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/database";
+import { voiceSessions } from "@/database/schemas/voiceSessions";
+
+export class VoiceSessionRepository {
+	async upsert(userId: string, channelId: string, joinedAt: Date) {
+		await db
+			.insert(voiceSessions)
+			.values({ userId, channelId, joinedAt, lastAwardedAt: joinedAt })
+			.onConflictDoUpdate({
+				target: voiceSessions.userId,
+				set: { channelId, joinedAt, lastAwardedAt: joinedAt },
+			});
+	}
+
+	async updateLastAwardedAt(userId: string, lastAwardedAt: Date) {
+		await db
+			.update(voiceSessions)
+			.set({ lastAwardedAt })
+			.where(eq(voiceSessions.userId, userId));
+	}
+
+	async deleteByUserId(userId: string) {
+		await db.delete(voiceSessions).where(eq(voiceSessions.userId, userId));
+	}
+
+	async findAll() {
+		return await db.select().from(voiceSessions);
+	}
+}
+
+export const voiceSessionRepository = new VoiceSessionRepository();

--- a/src/services/voiceActivityService.ts
+++ b/src/services/voiceActivityService.ts
@@ -1,0 +1,130 @@
+import type { UsingClient } from "seyfert";
+import { CONFIG } from "@/config";
+import { voiceActivityRepository } from "@/repositories/voiceActivityRepository";
+import { voiceSessionRepository } from "@/repositories/voiceSessionRepository";
+
+const MS_PER_MINUTE = 60 * 1000;
+
+interface VoiceSnapshot {
+	channelByUser: Map<string, string>;
+	humansByChannel: Map<string, number>;
+	mutedUsers: Set<string>;
+}
+
+export class VoiceActivityService {
+	async startSession(userId: string, channelId: string, joinedAt = new Date()) {
+		await voiceSessionRepository.upsert(userId, channelId, joinedAt);
+	}
+
+	async endSession(userId: string) {
+		await voiceSessionRepository.deleteByUserId(userId);
+	}
+
+	async getStats(userId: string) {
+		return await voiceActivityRepository.findByUserId(userId);
+	}
+
+	async getTop(limit = 10) {
+		return await voiceActivityRepository.getTop(limit);
+	}
+
+	async runAwardCycle(client: UsingClient) {
+		const sessions = await voiceSessionRepository.findAll();
+		if (!sessions.length) return;
+
+		const snapshot = await this.takeSnapshot(client);
+		const now = new Date();
+
+		for (const session of sessions) {
+			const channelId = snapshot.channelByUser.get(session.userId);
+
+			if (!channelId) {
+				await voiceSessionRepository.deleteByUserId(session.userId);
+				continue;
+			}
+
+			if (channelId !== session.channelId) {
+				// Move missed by the gateway handler; restart tracking on the new channel
+				await voiceSessionRepository.upsert(session.userId, channelId, now);
+				continue;
+			}
+
+			const active =
+				!snapshot.mutedUsers.has(session.userId) &&
+				(snapshot.humansByChannel.get(channelId) ?? 0) >=
+					CONFIG.VOICE_ACTIVITY.MIN_HUMANS;
+
+			if (!active) {
+				// Inactive interval does not count toward points
+				await voiceSessionRepository.updateLastAwardedAt(session.userId, now);
+				continue;
+			}
+
+			const elapsedMinutes = Math.floor(
+				(now.getTime() - session.lastAwardedAt.getTime()) / MS_PER_MINUTE,
+			);
+			if (!elapsedMinutes) continue;
+
+			await voiceActivityRepository.addMinutes(
+				session.userId,
+				elapsedMinutes,
+				CONFIG.VOICE_ACTIVITY.MINUTES_PER_POINT,
+			);
+			// Advance by whole minutes only, carrying the sub-minute remainder
+			await voiceSessionRepository.updateLastAwardedAt(
+				session.userId,
+				new Date(
+					session.lastAwardedAt.getTime() + elapsedMinutes * MS_PER_MINUTE,
+				),
+			);
+		}
+	}
+
+	async recoverOnStartup(client: UsingClient) {
+		const sessions = await voiceSessionRepository.findAll();
+		const snapshot = await this.takeSnapshot(client);
+		const now = new Date();
+		const sessionByUser = new Map(sessions.map((s) => [s.userId, s]));
+
+		for (const session of sessions) {
+			if (!snapshot.channelByUser.has(session.userId)) {
+				await voiceSessionRepository.deleteByUserId(session.userId);
+			}
+		}
+
+		for (const [userId, channelId] of snapshot.channelByUser) {
+			const session = sessionByUser.get(userId);
+			if (!session || session.channelId !== channelId) {
+				await voiceSessionRepository.upsert(userId, channelId, now);
+			}
+		}
+	}
+
+	private async takeSnapshot(client: UsingClient): Promise<VoiceSnapshot> {
+		const states =
+			(await client.cache.voiceStates?.values(CONFIG.GUILD_ID)) ?? [];
+		const channelByUser = new Map<string, string>();
+		const humansByChannel = new Map<string, number>();
+		const mutedUsers = new Set<string>();
+
+		for (const state of states) {
+			if (!state.channelId) continue;
+
+			const user = await state.user().catch(() => null);
+			if (!user || user.bot) continue;
+
+			channelByUser.set(state.userId, state.channelId);
+			humansByChannel.set(
+				state.channelId,
+				(humansByChannel.get(state.channelId) ?? 0) + 1,
+			);
+			if (state.selfMute || state.selfDeaf || state.mute || state.deaf) {
+				mutedUsers.add(state.userId);
+			}
+		}
+
+		return { channelByUser, humansByChannel, mutedUsers };
+	}
+}
+
+export const voiceActivityService = new VoiceActivityService();

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -800,4 +800,45 @@ export const Embeds = {
 			.setColor(0xe74c3c)
 			.setTimestamp();
 	},
+
+	voiceStatsEmbed(data: {
+		userId: string;
+		username: string;
+		avatarUrl?: string;
+		points: number;
+		totalMinutes: number;
+	}): Embed {
+		return new Embed()
+			.setTitle(`Actividad de voz de ${data.username}`)
+			.setColor("Blue")
+			.setThumbnail(data.avatarUrl || "")
+			.addFields([
+				{ name: "Puntos", value: `**${data.points}**`, inline: true },
+				{
+					name: "Tiempo en voz",
+					value: formatDurationForModEmbed(data.totalMinutes * 60),
+					inline: true,
+				},
+			])
+			.setFooter({ text: `ID: ${data.userId}` })
+			.setTimestamp();
+	},
+
+	voiceTopEmbed(data: {
+		users: Array<{ userId: string; points: number; totalMinutes: number }>;
+	}): Embed {
+		const lines = data.users.length
+			? data.users.map((u, i) => {
+					const medal =
+						i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : `${i + 1}.`;
+					return `${medal} <@${u.userId}> — **${u.points}** pts (${formatDurationForModEmbed(u.totalMinutes * 60)})`;
+				})
+			: ["*Sin datos.*"];
+
+		return new Embed()
+			.setTitle("🏆 Top Actividad en Voz")
+			.setDescription(lines.join("\n"))
+			.setColor(0xf1c40f)
+			.setTimestamp();
+	},
 };


### PR DESCRIPTION
## Qué hace

Puntos por actividad en canales de voz, separados del sistema de reputación (que es por ayudar): 1 punto por cada 10 minutos activos.

## Cómo

- Evento `voiceStateUpdate` abre/cierra sesiones; un ciclo cada 5 minutos muestrea el cache de voice states y acredita el tiempo.
- Anti-AFK: no se acredita si el miembro está muteado/ensordecido (propio o de servidor) o si el canal tiene menos de 2 humanos. Umbrales en `CONFIG.VOICE_ACTIVITY`.
- Acreditación atómica con arrastre de remanente (los minutos sueltos no se pierden entre ciclos).
- Sobrevive reinicios: tabla `voice_sessions` + `recoverOnStartup` que reconcilia contra los voice states reales (mismo patrón que `voiceRestrictService`).
- `/voz stats [usuario]` y `/voz top` con embeds al estilo de `/rep`.

## Limitaciones conocidas

- Al cambiar de canal se pierden los minutos aún no acreditados (máx ~5, tradeoff del diseño por ticks).
- Tras una caída larga, las sesiones de miembros que siguen en el mismo canal acreditan el intervalo completo de downtime (no se puede verificar mute/mín-humanos retroactivamente); para reinicios normales el impacto es despreciable.

## Deploy

Tablas nuevas (`voice_sessions`, `voice_activity`): `bun run db:push`.

Closes #19
