### PR TITLE
feat(economy): sistema de economía PyE Coins (MVP)

### DIFF
--- a/src/commands/economy/balance.ts
+++ b/src/commands/economy/balance.ts
@@ -1,0 +1,49 @@
+import {
+	type CommandContext,
+	createUserOption,
+	Declare,
+	Options,
+	SubCommand,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { economyService } from "@/services/economyService";
+import { Embeds } from "@/utils/embeds";
+
+const options = {
+	usuario: createUserOption({
+		description: "Usuario a consultar (por defecto, tú)",
+		required: false,
+	}),
+};
+
+@Declare({
+	name: "balance",
+	description: "Muestra el balance de PyE Coins de un usuario",
+})
+@Options(options)
+export class BalanceSubCommand extends SubCommand {
+	override async run(ctx: CommandContext<typeof options>) {
+		const user = ctx.options.usuario ?? ctx.author;
+
+		if (user.bot) {
+			return ctx.write({
+				embeds: [Embeds.errorEmbed("Error", "Los bots no tienen PyE Coins.")],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const coins = await economyService.balance(user.id);
+
+		await ctx.write({
+			embeds: [
+				Embeds.ecoBalanceEmbed({
+					userId: user.id,
+					username: user.username,
+					avatarUrl: user.avatarURL(),
+					coins,
+				}),
+			],
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/commands/economy/daily.ts
+++ b/src/commands/economy/daily.ts
@@ -1,0 +1,36 @@
+import { type CommandContext, Declare, SubCommand } from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { economyService } from "@/services/economyService";
+import { Embeds } from "@/utils/embeds";
+
+@Declare({
+	name: "daily",
+	description: "Reclama tu recompensa diaria de PyE Coins",
+})
+export class DailySubCommand extends SubCommand {
+	override async run(ctx: CommandContext) {
+		const result = await economyService.daily(ctx.author.id);
+
+		if (!result.ok) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Recompensa no disponible",
+						`Ya reclamaste tu recompensa diaria. Podrás volver a reclamarla <t:${result.availableAt}:R>.`,
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		await ctx.write({
+			embeds: [
+				Embeds.successEmbed(
+					"Recompensa diaria",
+					`Reclamaste **${result.amount} ${CONFIG.ECONOMY.CURRENCY}**. Ahora tienes **${result.balance}**.`,
+				),
+			],
+		});
+	}
+}

--- a/src/commands/economy/eco.ts
+++ b/src/commands/economy/eco.ts
@@ -1,0 +1,21 @@
+import { Command, Declare, Options } from "seyfert";
+import { BalanceSubCommand } from "./balance";
+import { DailySubCommand } from "./daily";
+import { RobSubCommand } from "./robar";
+import { TopSubCommand } from "./top";
+import { WorkSubCommand } from "./trabajar";
+import { TransferSubCommand } from "./transferir";
+
+@Declare({
+	name: "eco",
+	description: "Sistema de economía de PyE Coins",
+})
+@Options([
+	BalanceSubCommand,
+	DailySubCommand,
+	WorkSubCommand,
+	RobSubCommand,
+	TransferSubCommand,
+	TopSubCommand,
+])
+export default class EcoCommand extends Command {}

--- a/src/commands/economy/robar.ts
+++ b/src/commands/economy/robar.ts
@@ -1,0 +1,79 @@
+import {
+	type CommandContext,
+	createUserOption,
+	Declare,
+	Options,
+	SubCommand,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { economyService } from "@/services/economyService";
+import { Embeds } from "@/utils/embeds";
+
+const options = {
+	usuario: createUserOption({
+		description: "Usuario al que intentar robar",
+		required: true,
+	}),
+};
+
+@Declare({
+	name: "robar",
+	description: "Intenta robar PyE Coins a otro usuario",
+})
+@Options(options)
+export class RobSubCommand extends SubCommand {
+	override async run(ctx: CommandContext<typeof options>) {
+		const target = ctx.options.usuario;
+
+		if (target.id === ctx.author.id) {
+			return ctx.write({
+				embeds: [Embeds.errorEmbed("Error", "No puedes robarte a ti mismo.")],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		if (target.bot) {
+			return ctx.write({
+				embeds: [Embeds.errorEmbed("Error", "No puedes robarle a un bot.")],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const result = await economyService.rob(ctx.author.id, target.id);
+
+		if (!result.ok) {
+			const embed =
+				result.reason === "cooldown"
+					? Embeds.errorEmbed(
+							"Todavía te están buscando",
+							`Podrás intentar otro robo <t:${result.availableAt}:R>.`,
+						)
+					: Embeds.errorEmbed(
+							"Objetivo sin fondos",
+							`<@${target.id}> no tiene suficientes ${CONFIG.ECONOMY.CURRENCY} como para que valga la pena.`,
+						);
+			return ctx.write({ embeds: [embed], flags: MessageFlags.Ephemeral });
+		}
+
+		if (result.success) {
+			return ctx.write({
+				embeds: [
+					Embeds.successEmbed(
+						"Robo exitoso",
+						`Le robaste **${result.stolen} ${CONFIG.ECONOMY.CURRENCY}** a <@${target.id}>.`,
+					),
+				],
+			});
+		}
+
+		await ctx.write({
+			embeds: [
+				Embeds.errorEmbed(
+					"Te atraparon",
+					`Fallaste el robo a <@${target.id}> y pagaste una multa de **${result.fine} ${CONFIG.ECONOMY.CURRENCY}**.`,
+				),
+			],
+		});
+	}
+}

--- a/src/commands/economy/top.ts
+++ b/src/commands/economy/top.ts
@@ -1,0 +1,36 @@
+import {
+	type CommandContext,
+	createIntegerOption,
+	Declare,
+	Options,
+	SubCommand,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { economyService } from "@/services/economyService";
+import { Embeds } from "@/utils/embeds";
+
+const options = {
+	limite: createIntegerOption({
+		description: "Cantidad de usuarios a mostrar (por defecto 10)",
+		required: false,
+		min_value: 1,
+		max_value: 50,
+	}),
+};
+
+@Declare({
+	name: "top",
+	description: "Muestra el top de usuarios con más PyE Coins",
+})
+@Options(options)
+export class TopSubCommand extends SubCommand {
+	override async run(ctx: CommandContext<typeof options>) {
+		const limit = ctx.options.limite ?? 10;
+		const users = await economyService.top(limit);
+
+		await ctx.write({
+			embeds: [Embeds.ecoTopEmbed({ users })],
+			flags: MessageFlags.Ephemeral,
+		});
+	}
+}

--- a/src/commands/economy/trabajar.ts
+++ b/src/commands/economy/trabajar.ts
@@ -1,0 +1,36 @@
+import { type CommandContext, Declare, SubCommand } from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { economyService } from "@/services/economyService";
+import { Embeds } from "@/utils/embeds";
+
+@Declare({
+	name: "trabajar",
+	description: "Trabaja para ganar PyE Coins",
+})
+export class WorkSubCommand extends SubCommand {
+	override async run(ctx: CommandContext) {
+		const result = await economyService.work(ctx.author.id);
+
+		if (!result.ok) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Estás cansado",
+						`Ya trabajaste hace poco. Podrás volver a trabajar <t:${result.availableAt}:R>.`,
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		await ctx.write({
+			embeds: [
+				Embeds.successEmbed(
+					"Trabajo completado",
+					`Trabajaste como **${result.job}** y ganaste **${result.amount} ${CONFIG.ECONOMY.CURRENCY}**. Ahora tienes **${result.balance}**.`,
+				),
+			],
+		});
+	}
+}

--- a/src/commands/economy/transferir.ts
+++ b/src/commands/economy/transferir.ts
@@ -1,0 +1,80 @@
+import {
+	type CommandContext,
+	createIntegerOption,
+	createUserOption,
+	Declare,
+	Options,
+	SubCommand,
+} from "seyfert";
+import { MessageFlags } from "seyfert/lib/types";
+import { CONFIG } from "@/config";
+import { economyService } from "@/services/economyService";
+import { Embeds } from "@/utils/embeds";
+
+const options = {
+	usuario: createUserOption({
+		description: "Usuario que recibirá los PyE Coins",
+		required: true,
+	}),
+	cantidad: createIntegerOption({
+		description: "Cantidad a transferir",
+		required: true,
+		min_value: 1,
+	}),
+};
+
+@Declare({
+	name: "transferir",
+	description: "Transfiere PyE Coins a otro usuario",
+})
+@Options(options)
+export class TransferSubCommand extends SubCommand {
+	override async run(ctx: CommandContext<typeof options>) {
+		const { usuario, cantidad } = ctx.options;
+
+		if (usuario.id === ctx.author.id) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed("Error", "No puedes transferirte a ti mismo."),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		if (usuario.bot) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed("Error", "No puedes transferirle a un bot."),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		const result = await economyService.transfer(
+			ctx.author.id,
+			usuario.id,
+			cantidad,
+		);
+
+		if (!result.ok) {
+			return ctx.write({
+				embeds: [
+					Embeds.errorEmbed(
+						"Fondos insuficientes",
+						`No tienes **${cantidad} ${CONFIG.ECONOMY.CURRENCY}** para transferir.`,
+					),
+				],
+				flags: MessageFlags.Ephemeral,
+			});
+		}
+
+		await ctx.write({
+			embeds: [
+				Embeds.successEmbed(
+					"Transferencia realizada",
+					`Transferiste **${cantidad} ${CONFIG.ECONOMY.CURRENCY}** a <@${usuario.id}>. Recibió **${result.received}** (impuesto: **${result.tax}**).`,
+				),
+			],
+		});
+	}
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,20 @@ export const CONFIG = {
 		{ minPoints: 100, roleId: "769538041084903464" }, // Sabio
 		{ minPoints: 150, roleId: "838285410995929119" }, // Experto
 	],
+	ECONOMY: {
+		CURRENCY: "PyE Coins",
+		DAILY: { MIN: 100, MAX: 200, COOLDOWN_HOURS: 24 },
+		WORK: { MIN: 50, MAX: 150, COOLDOWN_HOURS: 1 },
+		ROB: {
+			COOLDOWN_HOURS: 4,
+			SUCCESS_RATE: 0.4,
+			STEAL_PCT: 0.15,
+			MAX_STEAL: 500,
+			FINE_PCT: 0.1,
+			MIN_TARGET_BALANCE: 100,
+		},
+		TRANSFER_TAX: 0.05,
+	},
 	OTHER: {
 		DISBOARD_ID: "302050872383242240",
 		THANKS_TERMS: [

--- a/src/database/schemas/economy.ts
+++ b/src/database/schemas/economy.ts
@@ -1,0 +1,9 @@
+import { integer, pgTable, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const economy = pgTable("economy", {
+	userId: varchar("user_id", { length: 64 }).primaryKey().notNull(),
+	coins: integer("coins").default(0).notNull(),
+	lastDaily: timestamp("last_daily"),
+	lastWork: timestamp("last_work"),
+	lastRob: timestamp("last_rob"),
+});

--- a/src/repositories/economyRepository.ts
+++ b/src/repositories/economyRepository.ts
@@ -1,0 +1,119 @@
+import { and, desc, eq, gte, isNull, lt, or, sql } from "drizzle-orm";
+import { db } from "@/database";
+import { economy } from "@/database/schemas/economy";
+
+export class EconomyRepository {
+	async findOrCreate(userId: string) {
+		const results = await db
+			.insert(economy)
+			.values({ userId })
+			.onConflictDoNothing()
+			.returning();
+		if (results[0]) return results[0];
+		const existing = await db
+			.select()
+			.from(economy)
+			.where(eq(economy.userId, userId))
+			.limit(1);
+		return (
+			existing[0] ?? {
+				userId,
+				coins: 0,
+				lastDaily: null,
+				lastWork: null,
+				lastRob: null,
+			}
+		);
+	}
+
+	async getBalance(userId: string) {
+		const result = await db
+			.select()
+			.from(economy)
+			.where(eq(economy.userId, userId))
+			.limit(1);
+		return result[0]?.coins ?? 0;
+	}
+
+	// The WHERE guard on the timestamp makes the claim atomic: a concurrent
+	// claim for the same user only succeeds once per cooldown window.
+	async claimDaily(userId: string, amount: number, cutoff: Date) {
+		const result = await db
+			.update(economy)
+			.set({ coins: sql`${economy.coins} + ${amount}`, lastDaily: new Date() })
+			.where(
+				and(
+					eq(economy.userId, userId),
+					or(isNull(economy.lastDaily), lt(economy.lastDaily, cutoff)),
+				),
+			)
+			.returning();
+		return result[0];
+	}
+
+	async claimWork(userId: string, amount: number, cutoff: Date) {
+		const result = await db
+			.update(economy)
+			.set({ coins: sql`${economy.coins} + ${amount}`, lastWork: new Date() })
+			.where(
+				and(
+					eq(economy.userId, userId),
+					or(isNull(economy.lastWork), lt(economy.lastWork, cutoff)),
+				),
+			)
+			.returning();
+		return result[0];
+	}
+
+	async setLastRob(userId: string) {
+		await db
+			.update(economy)
+			.set({ lastRob: new Date() })
+			.where(eq(economy.userId, userId));
+	}
+
+	// Removes up to `amount` coins without going below zero (currency sink).
+	async burn(userId: string, amount: number) {
+		await db
+			.update(economy)
+			.set({ coins: sql`GREATEST(${economy.coins} - ${amount}, 0)` })
+			.where(eq(economy.userId, userId));
+	}
+
+	// Atomically moves coins between users. `credit` can be lower than
+	// `deduct` (the difference is burned, e.g. transfer tax). The balance
+	// guard prevents overdrawing under concurrent operations.
+	async transfer(
+		fromId: string,
+		toId: string,
+		deduct: number,
+		credit: number,
+	): Promise<boolean> {
+		return await db.transaction(async (tx) => {
+			const debited = await tx
+				.update(economy)
+				.set({ coins: sql`${economy.coins} - ${deduct}` })
+				.where(and(eq(economy.userId, fromId), gte(economy.coins, deduct)))
+				.returning();
+			if (!debited.length) return false;
+			await tx
+				.insert(economy)
+				.values({ userId: toId, coins: credit })
+				.onConflictDoUpdate({
+					target: economy.userId,
+					set: { coins: sql`${economy.coins} + ${credit}` },
+				});
+			return true;
+		});
+	}
+
+	async getTop(limit: number) {
+		return await db
+			.select({ userId: economy.userId, coins: economy.coins })
+			.from(economy)
+			.orderBy(desc(economy.coins))
+			.limit(limit);
+	}
+}
+
+export const economyRepository = new EconomyRepository();

--- a/src/services/economyService.ts
+++ b/src/services/economyService.ts
@@ -1,0 +1,142 @@
+import { CONFIG } from "@/config";
+import { economyRepository } from "@/repositories/economyRepository";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+const WORK_JOBS = [
+	"desarrollador junior",
+	"tester de QA",
+	"administrador de bases de datos",
+	"diseñador UX",
+	"técnico de soporte",
+	"ingeniero DevOps",
+	"freelancer de WordPress",
+	"profesor de programación",
+	"revisor de pull requests",
+	"cazador de bugs",
+] as const;
+
+interface CooldownActive {
+	ok: false;
+	reason: "cooldown";
+	availableAt: number;
+}
+
+export class EconomyService {
+	private randomInt(min: number, max: number): number {
+		return Math.floor(Math.random() * (max - min + 1)) + min;
+	}
+
+	// Returns the unix timestamp (seconds) when the cooldown ends, or null if
+	// it is not active.
+	private cooldownEnd(last: Date | null, hours: number): number | null {
+		if (!last) return null;
+		const end = last.getTime() + hours * HOUR_MS;
+		return end > Date.now() ? Math.floor(end / 1000) : null;
+	}
+
+	private cooldownResult(availableAt: number): CooldownActive {
+		return { ok: false, reason: "cooldown", availableAt };
+	}
+
+	async daily(userId: string) {
+		const { MIN, MAX, COOLDOWN_HOURS } = CONFIG.ECONOMY.DAILY;
+		const row = await economyRepository.findOrCreate(userId);
+		const availableAt = this.cooldownEnd(row.lastDaily, COOLDOWN_HOURS);
+		if (availableAt) return this.cooldownResult(availableAt);
+
+		const amount = this.randomInt(MIN, MAX);
+		const cutoff = new Date(Date.now() - COOLDOWN_HOURS * HOUR_MS);
+		const updated = await economyRepository.claimDaily(userId, amount, cutoff);
+		if (!updated) {
+			return this.cooldownResult(
+				Math.floor((Date.now() + COOLDOWN_HOURS * HOUR_MS) / 1000),
+			);
+		}
+		return { ok: true as const, amount, balance: updated.coins };
+	}
+
+	async work(userId: string) {
+		const { MIN, MAX, COOLDOWN_HOURS } = CONFIG.ECONOMY.WORK;
+		const row = await economyRepository.findOrCreate(userId);
+		const availableAt = this.cooldownEnd(row.lastWork, COOLDOWN_HOURS);
+		if (availableAt) return this.cooldownResult(availableAt);
+
+		const amount = this.randomInt(MIN, MAX);
+		const cutoff = new Date(Date.now() - COOLDOWN_HOURS * HOUR_MS);
+		const updated = await economyRepository.claimWork(userId, amount, cutoff);
+		if (!updated) {
+			return this.cooldownResult(
+				Math.floor((Date.now() + COOLDOWN_HOURS * HOUR_MS) / 1000),
+			);
+		}
+		const job =
+			WORK_JOBS[this.randomInt(0, WORK_JOBS.length - 1)] ?? WORK_JOBS[0];
+		return { ok: true as const, amount, job, balance: updated.coins };
+	}
+
+	async rob(robberId: string, targetId: string) {
+		const {
+			COOLDOWN_HOURS,
+			SUCCESS_RATE,
+			STEAL_PCT,
+			MAX_STEAL,
+			FINE_PCT,
+			MIN_TARGET_BALANCE,
+		} = CONFIG.ECONOMY.ROB;
+		const robber = await economyRepository.findOrCreate(robberId);
+		const availableAt = this.cooldownEnd(robber.lastRob, COOLDOWN_HOURS);
+		if (availableAt) return this.cooldownResult(availableAt);
+
+		const targetBalance = await economyRepository.getBalance(targetId);
+		if (targetBalance < MIN_TARGET_BALANCE) {
+			return { ok: false as const, reason: "target_too_poor" as const };
+		}
+
+		// The attempt consumes the cooldown regardless of the outcome.
+		await economyRepository.setLastRob(robberId);
+
+		if (Math.random() < SUCCESS_RATE) {
+			const stolen = Math.min(Math.floor(targetBalance * STEAL_PCT), MAX_STEAL);
+			const moved = await economyRepository.transfer(
+				targetId,
+				robberId,
+				stolen,
+				stolen,
+			);
+			// The target spent their coins between the check and the transfer.
+			if (!moved)
+				return { ok: false as const, reason: "target_too_poor" as const };
+			return { ok: true as const, success: true as const, stolen };
+		}
+
+		// The fine is burned, not given to the target (currency sink).
+		const fine = Math.floor(robber.coins * FINE_PCT);
+		if (fine) await economyRepository.burn(robberId, fine);
+		return { ok: true as const, success: false as const, fine };
+	}
+
+	async transfer(fromId: string, toId: string, amount: number) {
+		// The tax is burned, not collected by anyone (currency sink).
+		const tax = Math.floor(amount * CONFIG.ECONOMY.TRANSFER_TAX);
+		const received = amount - tax;
+		const moved = await economyRepository.transfer(
+			fromId,
+			toId,
+			amount,
+			received,
+		);
+		if (!moved) return { ok: false as const, reason: "insufficient" as const };
+		return { ok: true as const, received, tax };
+	}
+
+	async balance(userId: string) {
+		return await economyRepository.getBalance(userId);
+	}
+
+	async top(limit = 10) {
+		return await economyRepository.getTop(limit);
+	}
+}
+
+export const economyService = new EconomyService();

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -773,6 +773,41 @@ export const Embeds = {
 			.setTimestamp();
 	},
 
+	ecoBalanceEmbed(data: {
+		userId: string;
+		username: string;
+		avatarUrl?: string;
+		coins: number;
+	}): Embed {
+		return new Embed()
+			.setTitle(`Balance de ${data.username}`)
+			.setColor("Gold")
+			.setThumbnail(data.avatarUrl || "")
+			.setDescription(
+				`<@${data.userId}> tiene **${data.coins} ${CONFIG.ECONOMY.CURRENCY}**.`,
+			)
+			.setFooter({ text: `ID: ${data.userId}` })
+			.setTimestamp();
+	},
+
+	ecoTopEmbed(data: {
+		users: Array<{ userId: string; coins: number }>;
+	}): Embed {
+		const lines = data.users.length
+			? data.users.map((u, i) => {
+					const medal =
+						i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : `${i + 1}.`;
+					return `${medal} <@${u.userId}> — **${u.coins}** ${CONFIG.ECONOMY.CURRENCY}`;
+				})
+			: ["*Sin datos.*"];
+
+		return new Embed()
+			.setTitle(`💰 Top ${CONFIG.ECONOMY.CURRENCY}`)
+			.setDescription(lines.join("\n"))
+			.setColor(0xf1c40f)
+			.setTimestamp();
+	},
+
 	topNegativeEmbed(data: {
 		users: Array<{ userId: string; points: number }>;
 		period: string;


### PR DESCRIPTION
## Qué hace

MVP del sistema de economía (PyE Coins) con mecánicas explícitas contra la superinflación que menciona el issue:

- `/eco daily` (100-200, cada 24h) y `/eco trabajar` (50-150, cada 1h) — única emisión de moneda.
- `/eco robar` (cada 4h, 40% de éxito, roba 15% del objetivo con tope de 500; si falla paga multa del 10% que se **quema**).
- `/eco transferir` con impuesto del 5% que también se **quema** (sink).
- `/eco balance [usuario]` y `/eco top`.

## Cómo

- Tabla única `economy` (saldo + timestamps de cooldown). Todas las mutaciones de saldo son UPDATEs atómicos con guards en el WHERE: un gasto concurrente no puede dejar saldo negativo y daily/work solo se cobran una vez por ventana. La transferencia corre en transacción dentro del repository.
- Tunables en `CONFIG.ECONOMY` (montos, cooldowns, tasas) — sin tablas de configuración.
- El cooldown de robar se consume aunque falle, para evitar spam de reintentos.

## Tienda

Se difiere a un follow-up: el servidor aún no tiene items definidos y meter un sistema de tienda sin items sería diseño especulativo. Cuando se decidan los items, se agregan sobre esta base.

## Deploy

Tabla nueva: `bun run db:push` (`drizzle/` gitignoreado).

Closes #10
